### PR TITLE
FIND-288:Fix server error handling

### DIFF
--- a/app/errors/middleware.py
+++ b/app/errors/middleware.py
@@ -1,0 +1,37 @@
+import logging
+
+from app.lib.api import ResourceNotFound
+from django.conf import settings
+
+from .views import page_not_found_error_view, server_error_view
+
+logger = logging.getLogger(__name__)
+
+
+class CustomExceptionMiddleware:
+    """Centralised exception handling and logging."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, exception):
+        """Handles exceptions raised by the client JSON api,
+        bad data and unhandled exceptions."""
+
+        # show error on screen in DEBUG mode
+        if settings.DEBUG:
+            raise  # re-raise error
+
+        if isinstance(exception, ResourceNotFound):
+            return page_not_found_error_view(
+                request=request, exception=exception
+            )
+
+        # Exception() raised or Unhandled exceptions
+
+        logger.error(exception, exc_info=True)
+        return server_error_view(request=request)

--- a/app/errors/middleware.py
+++ b/app/errors/middleware.py
@@ -28,9 +28,7 @@ class CustomExceptionMiddleware:
             raise  # re-raise error
 
         if isinstance(exception, ResourceNotFound):
-            return page_not_found_error_view(
-                request=request, exception=exception
-            )
+            return page_not_found_error_view(request=request)
 
         # Exception() raised or Unhandled exceptions
 

--- a/app/errors/middleware.py
+++ b/app/errors/middleware.py
@@ -33,5 +33,5 @@ class CustomExceptionMiddleware:
 
         # Exception() raised or Unhandled exceptions
 
-        logger.error(exception, exc_info=True)
+        logger.exception(exception)
         return server_error_view(request=request)

--- a/app/errors/middleware.py
+++ b/app/errors/middleware.py
@@ -1,5 +1,6 @@
 import logging
 
+import sentry_sdk
 from app.lib.api import ResourceNotFound
 from django.conf import settings
 
@@ -34,4 +35,5 @@ class CustomExceptionMiddleware:
         # Exception() raised or Unhandled exceptions
 
         logger.exception(exception)
+        sentry_sdk.capture_exception(exception)
         return server_error_view(request=request)

--- a/app/errors/views.py
+++ b/app/errors/views.py
@@ -31,4 +31,4 @@ def server_error_view(request, exception=None):
             "Internal Server Error: Template not found."
         )
     response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
-    return HttpResponseServerError(response)
+    return response

--- a/app/errors/views.py
+++ b/app/errors/views.py
@@ -31,4 +31,4 @@ def server_error_view(request, exception=None):
             "Internal Server Error: Template not found."
         )
     response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
-    return response
+    return HttpResponseServerError(response)

--- a/app/records/views.py
+++ b/app/records/views.py
@@ -66,14 +66,6 @@ def record_detail_view(request, id):
         record = record_details_by_id(id=id)
     except ResourceNotFound:
         raise Http404
-    except Exception as e:
-        context = {"exception_message": str(e)}
-        return TemplateResponse(
-            request=request,
-            template="errors/server_error.html",
-            context=context,
-            status=HTTPStatus.BAD_GATEWAY,
-        )
 
     context.update(
         record=record,

--- a/app/records/views.py
+++ b/app/records/views.py
@@ -7,10 +7,8 @@ from app.deliveryoptions.delivery_options import (
     AvailabilityCondition,
     construct_delivery_options,
 )
-from app.lib.api import ResourceNotFound
 from app.records.api import record_details_by_id
 from app.records.labels import FIELD_LABELS
-from django.http import Http404
 from django.template.response import TemplateResponse
 from sentry_sdk import capture_message
 
@@ -62,10 +60,7 @@ def record_detail_view(request, id):
         "field_labels": FIELD_LABELS,
     }
 
-    try:
-        record = record_details_by_id(id=id)
-    except ResourceNotFound:
-        raise Http404
+    record = record_details_by_id(id=id)
 
     context.update(
         record=record,
@@ -129,18 +124,7 @@ def related_records_view(request, id):
     template_name = "records/related_records.html"
     context: dict = {}
 
-    try:
-        record = record_details_by_id(id=id)
-    except ResourceNotFound:
-        raise Http404
-    except Exception as e:
-        context = {"exception_message": str(e)}
-        return TemplateResponse(
-            request=request,
-            template="errors/server_error.html",
-            context=context,
-            status=HTTPStatus.BAD_GATEWAY,
-        )
+    record = record_details_by_id(id=id)
 
     context.update(
         record=record,
@@ -155,18 +139,7 @@ def records_help_view(request, id):
     template_name = "records/new_to_archives.html"
     context: dict = {}
 
-    try:
-        record = record_details_by_id(id=id)
-    except ResourceNotFound:
-        raise Http404
-    except Exception as e:
-        context = {"exception_message": str(e)}
-        return TemplateResponse(
-            request=request,
-            template="errors/server_error.html",
-            context=context,
-            status=HTTPStatus.BAD_GATEWAY,
-        )
+    record = record_details_by_id(id=id)
 
     context.update(
         record=record,

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -141,9 +141,6 @@ class CatalogueSearchFormMixin(APIMixin, TemplateView):
         except ResourceNotFound:
             # no results
             return self.form_invalid()
-        except Exception as e:
-            logger.error(str(e))
-            return errors_view.server_error_view(request=request)
 
     @property
     def page(self) -> int:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "app.errors.middleware.CustomExceptionMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/config/urls.py
+++ b/config/urls.py
@@ -50,3 +50,11 @@ if apps.is_installed("debug_toolbar"):
     urlpatterns = [
         path("__debug__/", include("debug_toolbar.urls")),
     ] + urlpatterns
+
+if settings.DEBUG:
+    urlpatterns += [
+        path(
+            "500/",
+            errors_view.server_error_view,
+        )
+    ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from app.errors import views as errors_view
+from app.errors.views import page_not_found_error_view, server_error_view
 from app.records import converters
 from django.apps import apps
 from django.conf import settings
@@ -40,7 +40,7 @@ urlpatterns = [
     ),
     path(
         "404/",
-        errors_view.page_not_found_error_view,
+        page_not_found_error_view,
     ),
     path("admin/", admin.site.urls),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
@@ -54,6 +54,6 @@ if settings.DEBUG:
     urlpatterns += [
         path(
             "500/",
-            errors_view.server_error_view,
+            server_error_view,
         )
     ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -79,7 +79,7 @@ urlpatterns = (
         ),
         path(
             "404/",
-             page_not_found_error_view,
+            page_not_found_error_view,
         ),
         path("admin/", admin.site.urls),
     ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,7 +26,6 @@ from django.urls import include, path, register_converter
 register_converter(converters.IDConverter, "id")
 
 handler404 = "app.errors.views.page_not_found_error_view"
-handler500 = "app.errors.views.server_error_view"
 
 urlpatterns = [
     path("", include(("app.main.urls", "main"), namespace="main")),

--- a/test/lib/test_forms_fields.py
+++ b/test/lib/test_forms_fields.py
@@ -268,7 +268,7 @@ class BaseFormWithDynamicMultipleChoiceFieldTest(TestCase):
         form = MyTestForm(data)
         return form
 
-    def test_form_with_dymanic_multiple_choice_field_initial_attrs(self):
+    def test_form_with_dynamic_multiple_choice_field_initial_attrs(self):
 
         form = self.get_form_with_dynamic_multiple_choice_field()
         self.assertEqual(form.fields["dmc_field"].name, "dmc_field")

--- a/test/lib/test_forms_fields_exceptions.py
+++ b/test/lib/test_forms_fields_exceptions.py
@@ -1,0 +1,113 @@
+from datetime import datetime
+
+from app.lib.fields import BaseField, CharField
+from app.lib.forms import BaseForm
+from django.http import QueryDict
+from django.test import TestCase
+
+
+class NewFieldWithBadValidateTest(TestCase):
+
+    def get_form_with_new_field(self, data=None):
+
+        class MyTestForm(BaseForm):
+
+            class TestNewField(CharField):
+
+                def validate(self, value):
+                    try:
+                        datetime.strptime(value, "%Y-%m-%d")
+                    except ValueError:
+                        raise Exception("Value is not in format YYYY-MM-DD")
+                    super().validate(value)
+
+            def add_fields(self):
+                return {"new_field": MyTestForm.TestNewField()}
+
+        form = MyTestForm(data)
+        return form
+
+    def test_bad_validate_responds_with_error(self):
+        """validate() should not respond with any Error. Exception is raised here."""
+
+        data = QueryDict("")
+        form = self.get_form_with_new_field(data)
+
+        with self.assertRaises(Exception) as context:
+            _ = form.is_valid()
+
+        self.assertEqual(
+            "Value is not in format YYYY-MM-DD",
+            str(context.exception),
+        )
+
+
+class NewFieldWithBadCleanTest(TestCase):
+
+    def get_form_with_new_field(self, data=None):
+
+        class MyTestForm(BaseForm):
+
+            class TestNewField(BaseField):
+
+                def clean(self, value):
+                    value = super().clean(value)
+
+                    # transform value to something
+                    # Bad transformation / UNHANDLED transformation
+                    transformed_value = int(value)
+
+                    return transformed_value
+
+            def add_fields(self):
+                return {"new_field": MyTestForm.TestNewField()}
+
+        form = MyTestForm(data)
+        return form
+
+    def test_bad_clean_responds_with_error(self):
+        """clean() should not respond with any Error. Exception is raised here."""
+
+        data = QueryDict("")
+        form = self.get_form_with_new_field(data)
+
+        with self.assertRaises(Exception) as context:
+            _ = form.is_valid()
+
+        self.assertEqual(
+            "int() argument must be a string, a bytes-like object or a real number, not 'list'",
+            str(context.exception),
+        )
+
+
+class NewFieldWithBadBindTest(TestCase):
+
+    def get_form_with_new_field(self, data=None):
+
+        class MyTestForm(BaseForm):
+
+            class TestNewField(BaseField):
+
+                def bind(self, name, value):
+                    # A BAD Binding
+                    value = value[1]
+                    super().bind(name, value)
+
+            def add_fields(self):
+                return {"new_field": MyTestForm.TestNewField()}
+
+        form = MyTestForm(data)
+        return form
+
+    def test_bad_bind_responds_with_error(self):
+        """bind() should not respond with any Error. Exception is raised here."""
+
+        data = QueryDict("")
+
+        with self.assertRaises(Exception) as context:
+            _ = self.get_form_with_new_field(data)
+
+        self.assertEqual(
+            "list index out of range",
+            str(context.exception),
+        )

--- a/test/records/test_views_exceptions.py
+++ b/test/records/test_views_exceptions.py
@@ -50,9 +50,7 @@ class TestRecordViewExceptions(TestCase):
             "Unknown JSON API exception: THIS IS AN UNKNOWN API EXCEPTION",
             "".join(log1.output),
         )
-        self.assertIn(
-            "THIS IS AN UNKNOWN API EXCEPTION", "".join(log2.output)
-        )
+        self.assertIn("THIS IS AN UNKNOWN API EXCEPTION", "".join(log2.output))
         self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
 
         # check content as raising exception does not allow to test template

--- a/test/records/test_views_exceptions.py
+++ b/test/records/test_views_exceptions.py
@@ -1,11 +1,16 @@
+from http import HTTPStatus
 from test.utils import prevent_request_warnings
 
 import responses
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
 class TestRecordViewExceptions(TestCase):
+
+    def setUp(self):
+        # disable exception raised by client
+        self.client.raise_request_exception = False
 
     @prevent_request_warnings  # suppress test output: Not Found: /catalogue/id/Z123456/
     def test_no_matches_respond_with_404(self):
@@ -26,26 +31,44 @@ class TestRecordViewExceptions(TestCase):
 
         response = self.client.get("/catalogue/id/C123456/")
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(response.resolver_match.view_name, "records:details")
 
     @prevent_request_warnings
     @responses.activate
-    def test_unexpected_exception_responds_with_502(self):
+    def test_unexpected_exception_responds_with_server_error_500(self):
+
         responses.add(
             responses.GET,
             f"{settings.ROSETTA_API_URL}/get?id=C123456",
             body=Exception("THIS IS AN UNKNOWN API EXCEPTION"),
         )
 
-        # TODO: This test still outputs the error message "Bad Gateway: /catalogue/id/C123456/" to the console
-        with self.assertLogs(
-            "app.lib.api", level="ERROR"
-        ):  # assertLogs to suppress test console logging
+        with self.assertLogs("django.request", level="ERROR") as log:
             response = self.client.get("/catalogue/id/C123456/")
 
-        self.assertEqual(response.status_code, 502)
-        self.assertEqual(
-            response.context_data.get("exception_message"),
-            "THIS IS AN UNKNOWN API EXCEPTION",
+        self.assertIn("THIS IS AN UNKNOWN API EXCEPTION", "".join(log.output))
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        # check content as raising exception does not allow to test template
+        self.assertIn(
+            "There is a problem with the service",
+            response.content.decode("utf-8"),
+        )
+
+    @override_settings(
+        ROSETTA_API_URL="",
+    )
+    def test_missing_config_responds_with_server_error_500(self):
+
+        with self.assertLogs("django.request", level="ERROR") as log:
+            response = self.client.get("/catalogue/id/C123456/")
+
+        self.assertIn("ROSETTA_API_URL not set", "".join(log.output))
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        # check content as raising exception does not allow to test template
+        self.assertIn(
+            "There is a problem with the service",
+            response.content.decode("utf-8"),
         )

--- a/test/search/test_views_exceptions.py
+++ b/test/search/test_views_exceptions.py
@@ -1,5 +1,6 @@
-from django.test import TestCase, override_settings
 from http import HTTPStatus
+
+from django.test import TestCase, override_settings
 
 
 class TestCatalogueSearchViewExceptions(TestCase):

--- a/test/search/test_views_exceptions.py
+++ b/test/search/test_views_exceptions.py
@@ -1,5 +1,5 @@
-from django.conf import settings
 from django.test import TestCase, override_settings
+from http import HTTPStatus
 
 
 class TestCatalogueSearchViewExceptions(TestCase):
@@ -11,15 +11,15 @@ class TestCatalogueSearchViewExceptions(TestCase):
     @override_settings(
         ROSETTA_API_URL="",
     )
-    def test_missing_config_with_server_error(self):
+    def test_missing_config_responds_with_server_error_500(self):
 
         with self.assertLogs("django.request", level="ERROR") as log:
             response = self.client.get("/catalogue/search/")
 
         self.assertIn("ROSETTA_API_URL not set", "".join(log.output))
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
 
-        # check content as it does not allow to test template SERVER_ERROR_TEMPLATE
+        # check content as raising exception does not allow to test template
         self.assertIn(
             "There is a problem with the service",
             response.content.decode("utf-8"),

--- a/test/search/test_views_exceptions.py
+++ b/test/search/test_views_exceptions.py
@@ -5,16 +5,12 @@ from django.test import TestCase, override_settings
 
 class TestCatalogueSearchViewExceptions(TestCase):
 
-    def setUp(self):
-        # disable exception raised by client
-        self.client.raise_request_exception = False
-
     @override_settings(
         ROSETTA_API_URL="",
     )
-    def test_missing_config_responds_with_server_error_500(self):
+    def test_missing_config_with_server_error(self):
 
-        with self.assertLogs("django.request", level="ERROR") as log:
+        with self.assertLogs("app.errors.middleware", level="ERROR") as log:
             response = self.client.get("/catalogue/search/")
 
         self.assertIn("ROSETTA_API_URL not set", "".join(log.output))

--- a/test/search/test_views_exceptions.py
+++ b/test/search/test_views_exceptions.py
@@ -1,10 +1,12 @@
 from http import HTTPStatus
+from test.utils import prevent_request_warnings
 
 from django.test import TestCase, override_settings
 
 
 class TestCatalogueSearchViewExceptions(TestCase):
 
+    @prevent_request_warnings  # suppress test output: Internal Server Error: /catalogue/search/
     @override_settings(
         ROSETTA_API_URL="",
     )

--- a/test/utils.py
+++ b/test/utils.py
@@ -15,7 +15,7 @@ def prevent_request_warnings(original_function):
         # set logging level before triggering original function
         logger = logging.getLogger("django.request")
         previous_logging_level = logger.getEffectiveLevel()
-        logger.setLevel(logging.ERROR)
+        logger.setLevel(logging.CRITICAL)  # Suppresses ERROR and below
 
         # trigger original function that would throw error
         original_function(*args, **kwargs)


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-288](https://national-archives.atlassian.net/browse/FIND-288) 

## About these changes

Exception `ResourceNotFound()` is typically for `page_not_found_error_view()` and  Exception `Exception()` for `server_error_view()`

Issue
- When a page that queries the API is accessed ex http://localhost:65533/catalogue/search/,  http://localhost:65533/catalogue/id/C12345/ and we have a Exception() raised for the API Client or some configuration used by the API is invalid, or there is some unknown exception, the prod app/templates/errors/server_error.html template shows. However in this the Debug error trace does not show even in the console. Showing the trace would be helpful to debug particularly for unhandled exceptions.
-  Another example say during development the cleaning and validating field is unhandled. This would show the prod server error without a trace. Ideally the debug trace should show to fix any errors during development.
Unit tests have been written in test/lib/test_forms_fields_exceptions.py
- Also, the usage of calling server_error.html is increasingly more than one place `app/search/views.py, app/records/views.py`

This PR

- moves the error handling for those exceptions to a middleware, so the views can become cleaner when interacting with the API and the view should handle their specific Exceptions and let the middleware handle everything else. In development the developer should see the stack trace to debug. 
- Adds, Updates tests
- View server error page in DEBUG mode

For another PR, discussion - some thoughts - could be enhanced to show prod template in development using a switch.
The logging can be refactored and centralised. The client Exception names to distinguish them from Unhandled exceptions.



## How to check these changes

Switch between DEBUG=True/False
When Debug=False you will not see a css rendered page

1.  Remove the env ROSETTA_API_URL

http://localhost:65533/catalogue/search/
http://localhost:65533/catalogue/id/C12345/



2. Incorrect implementation of clean, validate methods

Add this to clean, validate field methods
```
from datetime import datetime
try:
	datetime.strptime(value, "%Y-%m-%d")
except ValueError:
	raise Exception("Value is not in format YYYY-MM-DD"
```

http://localhost:65533/catalogue/search/

3.  http://localhost:65533/500/ to view Server Error Page in DEBUG mode

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant


[FIND-288]: https://national-archives.atlassian.net/browse/FIND-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ