### PR TITLE
FIND-277: Add an app-specific accordion

### DIFF
--- a/app/templates/records/macros/accordion.html
+++ b/app/templates/records/macros/accordion.html
@@ -1,0 +1,19 @@
+{% macro etna_accordion(params) %}
+  <div class="etna-accordion"
+       data-multiselectable="true" data-module="etna-accordion">
+  {%- for item in params.accordionItems %}
+    <div class="etna-accordion__item" data-isopen="{{ item.open or 'false' }}">
+      <h3 class="etna-accordion__heading" id="{{ params.id }}-heading-{{ loop.index }}">
+        {{ item.title }}
+      </h3>
+      <div class="etna-accordion__body" id="{{ params.id }}-content-{{ loop.index }}">
+        {%- if item.text %}
+          <p>{{ item.text }}</p>
+        {%- else %}
+          {{ item.body | safe }}
+        {%- endif %}
+      </div>
+    </div>
+  {%- endfor %}
+  </div>
+{% endmacro %}

--- a/app/templates/records/record_detail.html
+++ b/app/templates/records/record_detail.html
@@ -64,20 +64,18 @@
         'title': 'Catalogue hierarchy',
         'body': hierarchy(record)
       }] %}
-      
-      {{ tnaAccordion({
-        'itemHeadingLevel': 3,
-        'items': accordion_items,
+
+      {{ etna_accordion({
+        'accordionItems': accordion_items,
         'id': 'record-extended-details',
-        'openMultipleItems': True
       }) }}
+
     </div>
   </div>
 </div>
 
 {{ related_records_block(record) }}
 
-</div>
 {% endblock %}
 
 {% block bodyEnd %}

--- a/app/templates/records/record_detail.html
+++ b/app/templates/records/record_detail.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% from 'components/accordion/macro.html' import tnaAccordion %}
+{% from 'records/macros/accordion.html' import etna_accordion %}
 {% from 'records/macros/whats_it_about.html' import whats_it_about %}
 {% from 'records/macros/information_boxes.html' import information_boxes %}
 {% from 'records/macros/detail_fields.html' import detail_fields %}

--- a/src/scripts/etna-accordion.mjs
+++ b/src/scripts/etna-accordion.mjs
@@ -1,0 +1,98 @@
+export class Accordion {
+  constructor($module) {
+    this.$module = $module;
+    this.$items = $module && $module.querySelectorAll(".etna-accordion__item");
+    if (!this.$module || !this.$items) {
+      return;
+    }
+
+    this.allowMultipleItemsOpen =
+      this.$module.dataset["multiselectable"] === "true";
+
+    this.$items.forEach(($item) => this.initItem($item));
+    this.initState();
+  }
+
+  initItem($item) {
+    const $heading = $item.querySelector(".etna-accordion__heading");
+    const $content = $item.querySelector(".etna-accordion__body");
+
+    if (!$heading || !$content) {
+      return;
+    }
+
+    $item.classList.add("etna-accordion__details");
+    $item.classList.remove("etna-accordion__item");
+
+    $heading.removeAttribute("class");
+
+    $content.classList.add("etna-accordion__content");
+    $content.classList.remove("etna-accordion__body");
+    $content.setAttribute("hidden", "");
+
+    const $headingButton = document.createElement("button");
+    $headingButton.classList.add("etna-accordion__summary");
+    $headingButton.setAttribute("type", "button");
+    $headingButton.setAttribute("aria-controls", $content.id);
+    $headingButton.innerText = $heading.innerText;
+    $heading.innerText = "";
+    $heading.appendChild($headingButton);
+
+    $headingButton.addEventListener("click", () => {
+      const isOpen = $headingButton.getAttribute("aria-expanded") === "true";
+      if (isOpen) {
+        this.closeItem($item);
+      } else {
+        this.openItem($item);
+      }
+    });
+  }
+
+  initState() {
+    this.$items.forEach(($item) => {
+      if ($item.dataset["isopen"] === "true") {
+        this.openItem($item);
+      } else {
+        this.closeItem($item);
+      }
+      $item.removeAttribute("data-isopen");
+    });
+  }
+
+  openItem($item) {
+    if (!this.allowMultipleItemsOpen) {
+      this.closeAllItemsExcept($item);
+    }
+    const $headingButton = $item.querySelector(".etna-accordion__summary");
+    const $content = $item.querySelector(".etna-accordion__content");
+    $headingButton.setAttribute("aria-expanded", "true");
+    $headingButton.setAttribute(
+      "aria-label",
+      `${$headingButton.innerText.trim()}, Hide this section`,
+    );
+    $content.removeAttribute("hidden");
+  }
+
+  closeItem($item) {
+    const $headingButton = $item.querySelector(".etna-accordion__summary");
+    const $content = $item.querySelector(".etna-accordion__content");
+    $headingButton.setAttribute("aria-expanded", "false");
+    $headingButton.setAttribute(
+      "aria-label",
+      `${$headingButton.innerText.trim()}, Show this section`,
+    );
+    $content.setAttribute("hidden", "");
+  }
+
+  closeAllItemsExcept($excludeItem) {
+    Array.from(this.$items)
+      .filter(
+        ($item) =>
+          $item.querySelector(".etna-accordion__summary") !== $excludeItem &&
+          $item
+            .querySelector(".etna-accordion__summary")
+            .getAttribute("aria-expanded") === "true",
+      )
+      .forEach(($item) => this.closeItem($item));
+  }
+}

--- a/src/scripts/record-details.js
+++ b/src/scripts/record-details.js
@@ -1,4 +1,5 @@
 import { Cookies } from "@nationalarchives/frontend/nationalarchives/all.mjs";
+import { Accordion } from "./etna-accordion.mjs";
 
 class toggleDetailsListDescriptions {
   constructor(checkbox, detailsList, cookies) {
@@ -99,3 +100,9 @@ if (
   embededPlayer.classList.add("tna-!--margin-top-m");
   youtubeLink.replaceWith(embededPlayer);
 }
+
+const $accordions = document.querySelectorAll('[data-module="etna-accordion"]');
+
+$accordions.forEach(($accordion) => {
+  new Accordion($accordion);
+});

--- a/src/styles/accordion.scss
+++ b/src/styles/accordion.scss
@@ -1,0 +1,166 @@
+@use "sass:math";
+@use "@nationalarchives/frontend/nationalarchives/tools/colour";
+@use "@nationalarchives/frontend/nationalarchives/tools/spacing";
+@use "@nationalarchives/frontend/nationalarchives/tools/typography";
+
+.etna-accordion {
+  @include spacing.space-above;
+
+  &__item {
+    @include spacing.space-above;
+  }
+
+  &__heading {
+    padding-top: spacing.space(1);
+  }
+
+  &__body {
+    padding-top: spacing.space(1);
+  }
+
+  &__details {
+    @include colour.colour-border("keyline", 1px, solid, bottom);
+
+    position: relative;
+    z-index: 1;
+
+    &:first-child {
+      @include colour.colour-border("keyline", 1px, solid, top);
+    }
+  }
+
+  &__details:has(&__summary:focus),
+  &__details:has(&__content:focus) {
+    z-index: 2;
+  }
+
+  &__summary {
+    width: 100%;
+    margin: 0;
+    padding: spacing.space(0.5) spacing.space(3) spacing.space(0.5)
+      spacing.space(1);
+
+    display: block;
+
+    position: relative;
+
+    line-height: inherit;
+    text-align: left;
+
+    list-style: none;
+
+    background: transparent;
+
+    border: none;
+    border-radius: 0.1px;
+
+    cursor: pointer;
+
+    @include colour.colour-font("font-dark");
+    @include typography.font-size(18);
+    @include typography.main-font(true);
+
+    * {
+      font-size: inherit;
+    }
+
+    &::before {
+      content: "";
+
+      width: 0;
+      height: 0;
+
+      position: absolute;
+      top: calc(50% - #{math.div(math.sqrt(3), 4)}rem);
+      right: 0.75rem;
+
+      border-width: #{math.div(math.sqrt(3), 2)}rem 0.5rem 0 0.5rem;
+      border-color: colour.colour-var("font-light") transparent;
+      border-style: solid;
+    }
+
+    &:hover,
+    &:focus-visible {
+      @include typography.interacted-text-decoration;
+      @include colour.colour-background("background-tint");
+
+      &::before {
+        border-color: colour.colour-var("font-dark") transparent;
+      }
+    }
+
+    &[aria-expanded="true"] {
+      &::before {
+        border-width: 0 0.5rem #{math.div(math.sqrt(3), 2)}rem 0.5rem;
+      }
+    }
+
+    &:active {
+      z-index: 1;
+    }
+  }
+
+  &__body,
+  &__content {
+    .tna-table-wrapper {
+      padding-right: 0;
+      padding-left: 0;
+
+      left: 0;
+    }
+  }
+
+  &__content {
+    padding: spacing.space(1);
+
+    position: relative;
+
+    border-radius: 0.1px;
+
+    &:has(.tna-table-wrapper):has(.tna-table) {
+      padding-right: 0;
+      padding-left: 0;
+    }
+
+    .tna-table {
+      width: calc(100% - #{spacing.space(2)});
+      margin-right: spacing.space(1);
+      margin-left: spacing.space(1);
+
+      &__caption {
+        padding-top: 0;
+        padding-bottom: spacing.space(1);
+
+        font-size: inherit;
+        line-height: inherit;
+        text-align: left;
+        caption-side: top;
+      }
+    }
+  }
+
+  @include colour.on-forced-colours {
+    &__summary {
+      &::before {
+        content: "\2193";
+
+        width: auto;
+        height: auto;
+
+        top: calc(50% - 0.5rem);
+
+        line-height: 1rem;
+
+        border: none;
+      }
+
+      &[aria-expanded="true"] {
+        &::before {
+          content: "\2191";
+
+          border: none;
+        }
+      }
+    }
+  }
+}

--- a/src/styles/record-details.scss
+++ b/src/styles/record-details.scss
@@ -3,6 +3,7 @@
 @use "@nationalarchives/frontend/nationalarchives/tools/media";
 @use "@nationalarchives/frontend/nationalarchives/tools/spacing";
 @use "@nationalarchives/frontend/nationalarchives/tools/typography";
+@use "./accordion";
 
 .back-link-group {
   display: flex;


### PR DESCRIPTION
## About these changes

This PR introduces a bespoke accordion implementation which will be used in a subsequent PR for [FIND-277](https://national-archives.atlassian.net/browse/FIND-277)

### Background 

FIND-277 will require the introduction of jump links to specific accordion items. Until now, the `record_detail.html` template had used the accordion component from TNA frontend, which does not currently permit the inclusion of IDs on accordion item headings (Note: while it does include IDs on accordion content, we cannot rely on the content being visible when the user clicks the jump link).

My initial thought was to extend the TNA frontend component to add unique IDs to each of the accordion headings, but advice from AJ is it would be better to make a bespoke accordion implementation for this project, as we have done for Explore The Collection. This PR introduces the bespoke accordion

### Implementation 

I've implemented this in three commits: 

1. The [first commit](https://github.com/nationalarchives/ds-catalogue/pull/64/commits/850b72be0aa3ce7b8326f376293f3886e2ae6cb6) removes a stray closing `div` tag I'd spotted - or rather that PyCharm spotted - in `record_detail.html`
2. The [second commit](https://github.com/nationalarchives/ds-catalogue/pull/64/commits/31414c95a8c7d7d46912c52b42b0cbcf4f934800) introduces a new `etna_accordion` macro, and uses this in place of `tnaAccordion` in `record_detail.html`. This new macro includes only those parameters we currently need, but it can be extended later if we find additional configuration would be helpful
3. The [final commit](https://github.com/nationalarchives/ds-catalogue/pull/64/commits/ba4cd748d23464749532986da5d6f7b0bf29d084) introduces the Sass and JavaScript to initialise the accordion

## How to check these changes

To check these changes you'll need to look at a few things with the code running locally and the browser in varying states:

1. First disable JavaScript in your web browser (to disable JavaScript in Firefox, type "about:config" in the address bar and press Enter. Then, search for "javascript.enabled" and toggle its value to false to disable it)
2. Visit a details page (here's [an example details page](http://localhost:65533/catalogue/id/C5798/?search=cT1qb25lcw==)) to confirm that the headings and content for "Order and viewing options" and "Catalogue hierarchy" are shown. This is what users will see if JavaScript doesn't run, so we don't want anything hidden from them.
3. Now enable JavaScript in your web browser and refresh the page
5. The "Order and viewing options" and "Catalogue hierarchy" should now be transformed into an accordion, which looks and behaves the same way as the Design System accordion

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant


[FIND-277]: https://national-archives.atlassian.net/browse/FIND-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ