### PR TITLE
Feature/find 265 integrate subjects on details page

### DIFF
--- a/app/records/constants.py
+++ b/app/records/constants.py
@@ -135,3 +135,5 @@ TNA_SUBJECTS = {
     "99": "Sewerage",
     "100": "Disarmament",
 }
+
+SUBJECTS_LIMIT = 20

--- a/app/records/labels.py
+++ b/app/records/labels.py
@@ -62,6 +62,7 @@ FIELD_LABELS = {
     "related_records": {"title": "Related records"},
     "restrictions_on_use": {"title": "Restrictions on use"},
     "separated_materials": {"title": "Separated material"},
+    "subjects": {"title": "Subjects"},
     "summary_title": {"title": "Summary title"},
     "title": {"title": "Title"},
     "unpublished_finding_aids": {"title": "Unpublished finding aids"},

--- a/app/records/models.py
+++ b/app/records/models.py
@@ -5,7 +5,7 @@ import re
 from typing import Any
 
 from app.lib.xslt_transformations import apply_schema_xsl, apply_series_xsl
-from app.records.constants import NON_TNA_LEVELS, TNA_LEVELS
+from app.records.constants import NON_TNA_LEVELS, TNA_LEVELS, SUBJECTS_LIMIT
 from app.records.utils import (
     change_discovery_record_details_links,
     extract,
@@ -455,3 +455,9 @@ class Record(APIModel):
             if item.level == "Series":
                 return item
         return None
+
+    @cached_property
+    def subjects(self) -> list[str]:
+        """Returns up to SUBJECTS_LIMIT items from the api value of the attr if found, empty list otherwise."""
+        return self.get("subjects", [])[:SUBJECTS_LIMIT]
+

--- a/app/templates/records/macros/detail_fields.html
+++ b/app/templates/records/macros/detail_fields.html
@@ -55,6 +55,7 @@
         'map_scale',
         'physical_condition',
         'closure_status',
+        'subjects',
         'custodial_history',
         'accumulation_dates',
         'accruals',
@@ -128,6 +129,16 @@
                 {# Output the field value and maybe the raw value #}
                 {{ record[field] | sanitise_record_field | safe }}
 
+              {% elif field == 'subjects' %}
+                <dl class="tna-dl-chips">
+                  {% for item in record[field] %}
+                    <dd>
+                      <a href="#" class="tna-dl-chips__item">
+                        {{ item }}
+                      </a>
+                    </dd>
+                  {% endfor %}
+                </dl> 
               {% else %}
                 {# Just output the field value #}
                 {{ record[field] | apply_generic_xsl | sanitise_record_field | safe }}
@@ -135,37 +146,6 @@
             </dd>
           {% endif %}
         {% endfor %}
-        <dt>Subjects</dt>
-        <dd>
-          <dl class="tna-dl-chips">
-            <dt>Topics</dt>
-            <dd>
-              <a href="#" class="tna-dl-chips__item">
-                Artwork
-              </a>
-            </dd>
-            <dd>
-              <a href="#" class="tna-dl-chips__item">
-                Art
-              </a>
-            </dd>
-            <dd>
-              <a href="#" class="tna-dl-chips__item">
-                Artists
-              </a>
-            </dd>
-            <dd>
-              <a href="#" class="tna-dl-chips__item">
-                Publicity
-              </a>
-            </dd>
-            <dd>
-              <a href="#" class="tna-dl-chips__item">
-                Propaganda
-              </a>
-            </dd>
-          </dl>
-        </dd> 
         <dt>Record URL</dt>
         <dd><span class="copy-url">{{ request.build_absolute_uri(url('records:details', kwargs={'id': record.iaid})) }}</span></dd>
       </dl>

--- a/test/records/test_models.py
+++ b/test/records/test_models.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from app.records.models import Record
 from django.test import SimpleTestCase
 
@@ -59,6 +60,7 @@ class RecordModelTests(SimpleTestCase):
         self.assertEqual(self.record.parent, None)
         self.assertEqual(self.record.is_tna, False)
         self.assertEqual(self.record.is_digitised, False)
+        self.assertEqual(self.record.subjects, [])
 
     def test_iaid(self):
 
@@ -957,3 +959,88 @@ class RecordModelTests(SimpleTestCase):
             self.record.url,
             "/catalogue/id/C11827825/",
         )
+
+    def test_subjects_with_data(self):
+        """Test that subjects returns list of subjects when present"""
+        self.record = Record(self.template_details)
+        # patch raw data
+        self.record._raw["subjects"] = [
+            "Military history",
+            "World War II",
+            "Intelligence services",
+            "Government records"
+        ]
+        self.assertEqual(self.record.subjects, [
+            "Military history",
+            "World War II", 
+            "Intelligence services",
+            "Government records"
+        ])
+
+    @patch('app.records.models.SUBJECTS_LIMIT', 3)
+    def test_subjects_respects_limit(self):
+        """Test that subjects list is limited to SUBJECTS_LIMIT"""
+        self.record = Record(self.template_details)
+        # Create more subjects than the limit
+        long_subjects_list = [
+            "Subject 1",
+            "Subject 2", 
+            "Subject 3",
+            "Subject 4",  # This should be excluded
+            "Subject 5",  # This should be excluded
+        ]
+        self.record._raw["subjects"] = long_subjects_list
+        
+        # Should only return first 3 items (mocked SUBJECTS_LIMIT)
+        expected = long_subjects_list[:3]
+        self.assertEqual(self.record.subjects, expected)
+        self.assertEqual(len(self.record.subjects), 3)
+
+    def test_subjects_with_single_item(self):
+        """Test that subjects works correctly with a single item"""
+        self.record = Record(self.template_details)
+        # patch raw data
+        self.record._raw["subjects"] = ["Military records"]
+        self.assertEqual(self.record.subjects, ["Military records"])
+
+    def test_subjects_empty_list_in_data(self):
+        """Test that subjects handles empty list in API data"""
+        self.record = Record(self.template_details)
+        # patch raw data
+        self.record._raw["subjects"] = []
+        self.assertEqual(self.record.subjects, [])
+
+    @patch('app.records.models.SUBJECTS_LIMIT', 5)
+    def test_subjects_exactly_at_limit(self):
+        """Test that subjects works when exactly at the limit"""
+        self.record = Record(self.template_details)
+        # Create exactly SUBJECTS_LIMIT items (mocked as 5)
+        exact_limit_subjects = [
+            "Subject 1",
+            "Subject 2",
+            "Subject 3", 
+            "Subject 4",
+            "Subject 5"
+        ]
+        self.record._raw["subjects"] = exact_limit_subjects
+        self.assertEqual(self.record.subjects, exact_limit_subjects)
+        self.assertEqual(len(self.record.subjects), 5)
+
+    def test_subjects_caching(self):
+        """Test that subjects property is cached (since it uses @cached_property)"""
+        self.record = Record(self.template_details)
+        # patch raw data
+        self.record._raw["subjects"] = ["Test subject"]
+        
+        # First access
+        first_result = self.record.subjects
+        
+        # Modify the raw data
+        self.record._raw["subjects"] = ["Modified subject"]
+        
+        # Second access should return cached result
+        second_result = self.record.subjects
+        
+        # Should be the same object (cached)
+        self.assertIs(first_result, second_result)
+        self.assertEqual(second_result, ["Test subject"])  # Original value, not modified


### PR DESCRIPTION
# Pull Request

Ticket URL: [](https://national-archives.atlassian.net/jira/software/c/projects/FIND/boards/145?selectedIssue=FIND-265)

## About these changes

This PR adds api derived subjects dynamically to the details page in the form of up to 20 lozenges. While the ticket asks for the lozenges to "if the user clicks on a tag THEN the user is taken to the catalogue results page for a filtered search on that tag", the filter for these tags hasn't yet been implemented. This will be done in a seperate ticket (FIND-317)

## How to check these changes

On the details page, the 'Subjects' section will now show subject 'lozenges' (if available). There is a limit of 20 lozenges but I cannot find an example with that many subjects. However, the automated tests do test that functionality.

Example 1:
http://localhost:65533/catalogue/id/C1359583/ - no Subjects in data (at time of writing - this is being added gradually by k-int), therefore no Subjects section

Example 2:
http://localhost:65533/catalogue/id/C10057264/ - has 7 subjects as follows: Litigation, Piracy and privateering, Europe and Russia, International, Armed Forces (General Administration) & Navy

Hyperlinks are empty anchors until FIND-317 is implemented.

Please note the changes to the template need closer attention as Jinja2 is not my forte.

