### PR TITLE
Feature/find 316 correct duplicated use of date filters

### DIFF
--- a/app/search/views.py
+++ b/app/search/views.py
@@ -362,6 +362,22 @@ class CatalogueSearchView(CatalogueSearchFormMixin):
                     "title": "Remove record to date",
                 }
             )
+        if self.request.GET.get("opening_date_from", None):
+            selected_filters.append(
+                { 
+                    "label": f"Record opening date from: {self.request.GET.get('opening_date_from')}",
+                    "href": f"?{qs_remove_value(self.request.GET, 'opening_date_from')}",
+                    "title": "Remove record opening from date",
+                }
+            )
+        if self.request.GET.get("opening_date_to", None):
+            selected_filters.append(
+                {
+                    "label": f"Record opening date to: {self.request.GET.get('opening_date_to')}",
+                    "href": f"?{qs_remove_value(self.request.GET, 'opening_date_to')}",
+                    "title": "Remove record opening to date",
+                }
+            )
         if levels := self.form.fields[FieldsConstant.LEVEL].value:
             levels_lookup = {}
             for _, v in TNA_LEVELS.items():

--- a/app/templates/search/catalogue.html
+++ b/app/templates/search/catalogue.html
@@ -118,7 +118,7 @@
     {{ collections_tna(request, collections) }}
     {{ subjects_tna(request, subjects) }}
     {{ levels_tna(request, form.fields['level']) }}
-    {{ date_range(request, 'date', 'date', 'Filter by record opening date') }}
+    {{ date_range(request, 'opening_date', 'opening_date', 'Filter by record opening date') }}
     {{ closure_statuses_tna(request, closure_statuses) }}
     
     


### PR DESCRIPTION
# Pull Request

Ticket URL: https://national-archives.atlassian.net/browse/FIND-316

## About these changes

On the Search results page:
'Filter by record date' and 'Filter by record opening date' were using the same parameters (date_from and date_to).
The latter filter has now been changed to opening_date_from and opening_date_to.

## How to check these changes

On http://localhost:65533/catalogue/search/?q=wantage, set filters as described above and all 4 filters are visible - check the url too as the parameters will now include date_from, date_to, opening_date_from and opening_date_to.

NOTE: the functionality behind these filters hasn't yet been implemented - just the front end.


