### PR TITLE
FIND-310: Hide field descriptions tracking

### DIFF
--- a/src/scripts/analytics.js
+++ b/src/scripts/analytics.js
@@ -19,4 +19,24 @@ if (ga4Id) {
       },
     },
   ]);
+
+  analytics.addListeners(
+    "#field-descriptions",
+    "document",
+    [
+      {
+        targetElement: "#field-descriptions-hide",
+        on: "change",
+        rootData: {
+          data_component_name: "checkboxes",
+          data_link: ($el) =>
+            `Hide field descriptions:${helpers.valueGetters.checked($el)}`,
+          data_section: "Record details",
+          data_link_type: "checkboxes",
+          data_position: 1,
+        },
+      },
+    ],
+    "select_feature",
+  );
 }

--- a/src/scripts/analytics.js
+++ b/src/scripts/analytics.js
@@ -22,11 +22,20 @@ if (ga4Id) {
 
   analytics.addListeners(
     "#field-descriptions",
-    "document",
+    "field_descriptions",
     [
       {
         targetElement: "#field-descriptions-hide",
         on: "change",
+        data: {
+          state: helpers.valueGetters.checked,
+          value: ($el) => $el.parentNode.innerText.trim(),
+          group: ($el, $scope) =>
+            $scope
+              .closest(".tna-form__group")
+              ?.querySelector(".tna-form__heading")
+              ?.innerText?.trim(),
+        },
         rootData: {
           data_component_name: "checkboxes",
           data_link: ($el) =>


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-310 - Interaction tracking for hide glossary checkbox](https://national-archives.atlassian.net/browse/FIND-310)

## About these changes

Uses the analytics library in TNA Frontend to introduce tracking described in the Jira ticket:

- "event" should be "tna.select_feature"
- "data_component_name" should be "checkboxes"`
- "data_link" should be "Hide field descriptions:[checked|unchecked]
- "data_link_type" should be "checkboxes"
- "data_position" should be 1
- "data_section" should be "Record details" 

When the field is changed to checked state, the following object is pushed to `dataLayer`

```json
{
  "event": "tna.checkboxes.toggle",
  "tna.event.state": "checked",
  "tna.event.value": "Hide field descriptions",
  "tna.event.group": "Record details",
  "tna.event.name": "tna.checkboxes.toggle",
  "tna.event.xPath": "id(\"field-descriptions-hide\")",
  "tna.event.targetElement": ".tna-checkboxes__item input",
  "tna.event.timeSincePageLoad": 82787,
  "tna.event.index": 1,
  "tna.event.instance": 1,
  "tna.event.scope": ".tna-checkboxes",
  "tna.event.areaName": "checkboxes"
}
```

When the field is changed to an unchecked state, the following object is pushed to the `dataLayer`

```json
{
  "event": "tna.checkboxes.toggle",
  "tna.event.state": "unchecked",
  "tna.event.value": "Hide field descriptions",
  "tna.event.group": "Record details",
  "tna.event.name": "tna.checkboxes.toggle",
  "tna.event.xPath": "id(\"field-descriptions-hide\")",
  "tna.event.targetElement": ".tna-checkboxes__item input",
  "tna.event.timeSincePageLoad": 20885,
  "tna.event.index": 1,
  "tna.event.instance": 1,
  "tna.event.scope": ".tna-checkboxes",
  "tna.event.areaName": "checkboxes"
}
```

## How to check these changes

Having first cloned this branch, navigate to a [details page](http://localhost:65533/catalogue/id/0125874efb9c41f78f1cfdbdb1544e08/?search=cT1GZWxpeCtSdWRkaWNr) and interact with the "Hide field descriptions" checkbox. 

You should see the relevant object (above) logged to the `dataLayer` (you can use `console.log(dataLayer.at(-1))` to quickly the object, provided you've not interacted with any other tracked elements)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant
