### PR TITLE
Feature/find 319 add related content to details page using subject tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See [Sentry's official guide](https://docs.sentry.io/platforms/python/guides/dja
 | Variable                   | Purpose                                                                    |
 | -------------------------- | -------------------------------------------------------------------------- |
 | `ROSETTA_API_URL`          | The base API URL for Rosetta, including the `/rosetta/data` path           |
+| `WAGTAIL_API_URL`          | The base API URL for Wagtail                                               |
 | `DELIVERY_OPTIONS_API_URL` | Api for Delivery options                                                   |
 | `DCS_PREFIXES`             | Comma separated list of document prefixes for distressing content          |
 | `STAFFIN_IP_ADDRESSES`     | Comma separated list of CIDR format IP addresses identifying staff access  |

--- a/app/records/models.py
+++ b/app/records/models.py
@@ -465,7 +465,7 @@ class Record(APIModel):
     @property
     def subjects_enrichment(self) -> dict:
         """Returns subjects enrichment data if available."""
-        return getattr(self, '_subjects_enrichment', {})
+        return getattr(self, "_subjects_enrichment", {})
 
     @property
     def has_subjects_enrichment(self) -> bool:

--- a/app/records/models.py
+++ b/app/records/models.py
@@ -460,3 +460,14 @@ class Record(APIModel):
     def subjects(self) -> list[str]:
         """Returns up to SUBJECTS_LIMIT items from the api value of the attr if found, empty list otherwise."""
         return self.get("subjects", [])[:SUBJECTS_LIMIT]
+
+    # Add to your Record class in app/records/models.py
+    @property
+    def subjects_enrichment(self) -> dict:
+        """Returns subjects enrichment data if available."""
+        return getattr(self, '_subjects_enrichment', {})
+
+    @property
+    def has_subjects_enrichment(self) -> bool:
+        """Check if this record has enrichment data available."""
+        return bool(self.subjects_enrichment)

--- a/app/records/views.py
+++ b/app/records/views.py
@@ -1,7 +1,9 @@
 import logging
 import os
+import pprint as pp
 from http import HTTPStatus
 
+import requests
 from app.deliveryoptions.api import delivery_options_request_handler
 from app.deliveryoptions.delivery_options import (
     AvailabilityCondition,
@@ -10,13 +12,10 @@ from app.deliveryoptions.delivery_options import (
 from app.deliveryoptions.helpers import BASE_TNA_DISCOVERY_URL
 from app.records.api import record_details_by_id
 from app.records.labels import FIELD_LABELS
+from django.conf import settings
 from django.template.response import TemplateResponse
 from django.utils.text import slugify
-from django.conf import settings
-import requests
 from sentry_sdk import capture_message
-
-import pprint as pp
 
 # TODO: Implement record_detail_by_reference once Rosetta has support
 # from app.records.api import record_details_by_ref
@@ -62,29 +61,27 @@ def get_subjects_enrichment(subjects_list: list[str], limit: int = 10) -> dict:
     Makes API call to enrich subjects data for a single record.
     Returns enrichment data or empty dict on failure.
     """
-    print(f"Subjects: {subjects_list}")
     if not subjects_list:
         return {}
-    
+
     slugified_subjects = [slugify(subject) for subject in subjects_list]
     subjects_param = ",".join(slugified_subjects)
 
-    print(f"Slugified: {subjects_param}")
-    
     try:
         response = requests.get(
             f"{settings.WAGTAIL_API_URL}/article_tags",
-            params={
-                'tags': subjects_param,
-                'limit': limit
-            },
-            timeout=getattr(settings, 'SUBJECTS_API_TIMEOUT', 5)
+            params={"tags": subjects_param, "limit": limit},
+            timeout=getattr(settings, "SUBJECTS_API_TIMEOUT", 5),
         )
         response.raise_for_status()
-        logger.info(f"Successfully fetched subjects enrichment for: {subjects_param}")
+        logger.info(
+            f"Successfully fetched subjects enrichment for: {subjects_param}"
+        )
         return response.json()
     except requests.RequestException as e:
-        logger.warning(f"Failed to fetch subjects enrichment for {subjects_param}: {e}")
+        logger.warning(
+            f"Failed to fetch subjects enrichment for {subjects_param}: {e}"
+        )
         return {}
 
 
@@ -101,15 +98,14 @@ def record_detail_view(request, id):
 
     if record.subjects:
         subjects_enrichment = get_subjects_enrichment(
-            record.subjects,
-            limit=getattr(settings, 'SUBJECTS_API_LIMIT', 10)
+            record.subjects, limit=getattr(settings, "SUBJECTS_API_LIMIT", 10)
         )
         record._subjects_enrichment = subjects_enrichment
-        logger.info(f"Enriched record {record.iaid} with {len(subjects_enrichment)} subject items")
+        logger.info(
+            f"Enriched record {record.iaid} with {len(subjects_enrichment)} subject items"
+        )
     else:
         record._subjects_enrichment = {}
-
-    print(f"Record: {record}")
 
     context.update(
         record=record,

--- a/app/templates/records/macros/related_content_block.html
+++ b/app/templates/records/macros/related_content_block.html
@@ -1,0 +1,49 @@
+{% macro related_content_block(record) %}
+<div class="tna-container">
+  <div class="tna-column tna-column--full tna-!--margin-top-l">
+    <h2 class="tna-heading-l">Related content</h2>
+  </div>
+</div>
+<div class="tna-container">
+  {% if record.has_subjects_enrichment %}
+    {% set filtered_subjects = [] %}
+    {% for subject_item in record.subjects_enrichment %}
+      {% if not subject_item.is_newly_published %}
+        {% set _ = filtered_subjects.append(subject_item) %}
+      {% endif %}
+    {% endfor %}
+    
+    {% for subject_item in filtered_subjects[:3] %}
+      <div class="tna-column tna-column--width-1-3 tna-column--full-small tna-column--full-tiny tna-!--margin-top-m">
+        <div class="tna-aside tna-aside--tight tna-background-accent full-height-aside">
+          <hgroup class="tna-hgroup-m">
+            <p class="tna-hgroup__supertitle">{{ subject_item.type_label }}</p>
+          </hgroup>
+          
+          {% if subject_item.teaser_image %}
+            <picture>
+              {% if subject_item.teaser_image.webp %}
+                <source srcset="{{ subject_item.teaser_image.webp.full_url }}" type="image/webp">
+              {% endif %}
+              <img 
+                src="{{ subject_item.teaser_image.jpeg.full_url }}" 
+                alt="{{ subject_item.teaser_image.title|default(subject_item.teaser_image.description)|default('') }}"
+                width="{{ subject_item.teaser_image.jpeg.width }}"
+                height="{{ subject_item.teaser_image.jpeg.height }}"
+                loading="lazy"
+              >
+            </picture>
+          {% endif %}
+          
+          <hgroup class="tna-hgroup-m">
+            <h3 class="tna-hgroup__title"><a href="{{ subject_item.full_url }}">{{ subject_item.title }}</a></h3>
+          </hgroup>
+          
+          <p>{{ subject_item.teaser_text }}</p>
+          <p><a href="">See more</a></p>
+        </div>
+      </div>
+    {% endfor %}
+  {% endif %}
+</div>
+{% endmacro %}

--- a/app/templates/records/record_detail.html
+++ b/app/templates/records/record_detail.html
@@ -9,6 +9,7 @@
 {% from 'records/macros/series_information.html' import series_information %}
 {% from 'records/macros/top_navigation.html' import top_navigation %}
 {% from 'records/macros/related_records_block.html' import related_records_block %}
+{% from 'records/macros/related_content_block.html' import related_content_block %}
 
 {%- set pageTitle = (record.summary_title or '[No title]') | striptags -%}
 
@@ -73,6 +74,10 @@
     </div>
   </div>
 </div>
+
+{% if record.has_subjects_enrichment %}
+  {{ related_content_block(record) }}
+{% endif %}
 
 {{ related_records_block(record) }}
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -171,6 +171,9 @@ GA4_ID = os.environ.get("GA4_ID", "")
 
 ROSETTA_API_URL = os.getenv("ROSETTA_API_URL")
 
+# Maximum number of subject/article_tags returned from Wagtail
+SUBJECTS_API_LIMIT: int = 3
+
 # DORIS is TNA's Document Ordering System that contains Delivery Options data
 DELIVERY_OPTIONS_API_URL = os.getenv("DELIVERY_OPTIONS_API_URL")
 

--- a/test/records/test_models.py
+++ b/test/records/test_models.py
@@ -62,6 +62,8 @@ class RecordModelTests(SimpleTestCase):
         self.assertEqual(self.record.is_tna, False)
         self.assertEqual(self.record.is_digitised, False)
         self.assertEqual(self.record.subjects, [])
+        self.assertEqual(self.record.subjects_enrichment, {})
+        self.assertEqual(self.record.has_subjects_enrichment, False)
 
     def test_iaid(self):
 

--- a/test/records/test_related_content.py
+++ b/test/records/test_related_content.py
@@ -3,29 +3,35 @@ Tests for subjects enrichment functionality
 """
 
 from unittest.mock import Mock, patch
-from django.test import TestCase, override_settings
-import responses
-from jinja2 import Environment, BaseLoader
-from django.utils.text import slugify
+
 import requests
+import responses
+from django.test import TestCase, override_settings
+from django.utils.text import slugify
+from jinja2 import BaseLoader, Environment
 
 
 @override_settings(
-    WAGTAIL_API_URL='https://test-api.example.com',
+    WAGTAIL_API_URL="https://test-api.example.com",
     SUBJECTS_API_TIMEOUT=5,
-    SUBJECTS_API_LIMIT=10
+    SUBJECTS_API_LIMIT=10,
 )
 class SubjectsEnrichmentTests(TestCase):
     """Tests for the new subjects enrichment functionality"""
-    
+
     def setUp(self):
         # Sample record data like what comes from your API
         self.sample_record_data = {
             "iaid": "C123456",
             "title": "RAF Operations File",
-            "subjects": ["World War, 1939-1945", "Aviation", "Royal Air Force", "Military operations"]
+            "subjects": [
+                "World War, 1939-1945",
+                "Aviation",
+                "Royal Air Force",
+                "Military operations",
+            ],
         }
-        
+
         # Mock enrichment API response (matching Wagtail API structure)
         self.mock_enrichment_response = {
             "meta": {"total_count": 3},
@@ -38,7 +44,7 @@ class SubjectsEnrichmentTests(TestCase):
                         "detail_url": "https://test-api.example.com/v2/pages/1/",
                         "html_url": "https://example.com/guides/raf-operations-wwii",
                         "slug": "raf-operations-wwii",
-                        "first_published_at": "2023-01-15T10:00:00.000000Z"
+                        "first_published_at": "2023-01-15T10:00:00.000000Z",
                     },
                     "introduction": "A comprehensive guide to researching Royal Air Force operations during WWII...",
                     "teaser_image": {
@@ -46,9 +52,13 @@ class SubjectsEnrichmentTests(TestCase):
                         "title": "Spitfire aircraft",
                         "width": 800,
                         "height": 600,
-                        "download_url": "https://example.com/images/spitfire.jpg"
+                        "download_url": "https://example.com/images/spitfire.jpg",
                     },
-                    "tags": ["world-war-1939-1945", "aviation", "royal-air-force"]
+                    "tags": [
+                        "world-war-1939-1945",
+                        "aviation",
+                        "royal-air-force",
+                    ],
                 },
                 {
                     "id": 2,
@@ -56,11 +66,11 @@ class SubjectsEnrichmentTests(TestCase):
                     "meta": {
                         "type": "blog.BlogPage",
                         "html_url": "https://example.com/blog/new-aviation-docs",
-                        "first_published_at": "2024-12-01T10:00:00.000000Z"
+                        "first_published_at": "2024-12-01T10:00:00.000000Z",
                     },
                     "introduction": "Recently published research on newly discovered aviation documents...",
                     "teaser_image": None,
-                    "tags": ["aviation"]
+                    "tags": ["aviation"],
                 },
                 {
                     "id": 3,
@@ -68,15 +78,15 @@ class SubjectsEnrichmentTests(TestCase):
                     "meta": {
                         "type": "articles.ArticlePage",
                         "html_url": "https://example.com/articles/aviation-tech",
-                        "first_published_at": "2023-06-10T10:00:00.000000Z"
+                        "first_published_at": "2023-06-10T10:00:00.000000Z",
                     },
                     "introduction": "Exploring the technological advances in military aviation...",
                     "teaser_image": None,
-                    "tags": ["military-operations", "aviation"]
-                }
-            ]
+                    "tags": ["military-operations", "aviation"],
+                },
+            ],
         }
-    
+
     # Test 1: Subject slugification for API calls
     def test_subject_slugification(self):
         """Test that subjects are properly slugified for API calls"""
@@ -88,110 +98,117 @@ class SubjectsEnrichmentTests(TestCase):
             ("D-Day Landings", "d-day-landings"),
             ("Women's Land Army", "womens-land-army"),
         ]
-        
+
         for subject, expected_slug in test_cases:
             with self.subTest(subject=subject):
                 actual_slug = slugify(subject)
                 self.assertEqual(actual_slug, expected_slug)
-    
+
     # Test 2: Record model - subjects property exists
     def test_record_subjects_property(self):
         """Test that Record.subjects property works correctly"""
         from app.records.models import Record
-        
+
         record = Record(self.sample_record_data)
-        
+
         # Test that subjects property exists and returns expected data
         self.assertEqual(len(record.subjects), 4)
         self.assertIn("World War, 1939-1945", record.subjects)
         self.assertIn("Aviation", record.subjects)
         self.assertIn("Royal Air Force", record.subjects)
         self.assertIn("Military operations", record.subjects)
-    
+
     # Test 3: get_subjects_enrichment function success
     @responses.activate
     def test_get_subjects_enrichment_success(self):
         """Test successful API call for subjects enrichment"""
         from app.records.views import get_subjects_enrichment
-        
+
         responses.add(
             responses.GET,
             "https://test-api.example.com/article_tags",
             json=self.mock_enrichment_response,
             status=200,
         )
-        
+
         result = get_subjects_enrichment(self.sample_record_data["subjects"])
-        
+
         self.assertIsInstance(result, dict)
         self.assertIn("items", result)
         self.assertEqual(len(result["items"]), 3)
-        self.assertEqual(result["items"][0]["title"], "RAF Operations in World War II")
-        
+        self.assertEqual(
+            result["items"][0]["title"], "RAF Operations in World War II"
+        )
+
         # Check that API was called with correct parameters
         self.assertEqual(len(responses.calls), 1)
         request_url = responses.calls[0].request.url
-        self.assertIn("tags=world-war-1939-1945%2Caviation%2Croyal-air-force%2Cmilitary-operations", request_url)
-    
+        self.assertIn(
+            "tags=world-war-1939-1945%2Caviation%2Croyal-air-force%2Cmilitary-operations",
+            request_url,
+        )
+
     # Test 4: get_subjects_enrichment function failure
     @responses.activate
     def test_get_subjects_enrichment_failure(self):
         """Test that API failures are handled gracefully"""
         from app.records.views import get_subjects_enrichment
-        
+
         responses.add(
             responses.GET,
             "https://test-api.example.com/article_tags",
             status=500,
         )
-        
+
         result = get_subjects_enrichment(self.sample_record_data["subjects"])
-        
+
         # Should return empty dict on failure
         self.assertEqual(result, {})
-    
+
     # Test 5: get_subjects_enrichment with empty subjects
     def test_get_subjects_enrichment_empty_subjects(self):
         """Test get_subjects_enrichment with empty subjects list"""
         from app.records.views import get_subjects_enrichment
-        
+
         result = get_subjects_enrichment([])
-        
+
         # Should return empty dict without making API call
         self.assertEqual(result, {})
-    
+
     # Test 6: Record model - subjects_enrichment property
     def test_record_subjects_enrichment_property(self):
         """Test that Record.subjects_enrichment works correctly"""
         from app.records.models import Record
-        
+
         record = Record(self.sample_record_data)
-        
+
         # Test default state (no enrichment data)
         self.assertEqual(record.subjects_enrichment, {})
-        
+
         # Test with enrichment data
         record._subjects_enrichment = self.mock_enrichment_response
-        self.assertEqual(record.subjects_enrichment, self.mock_enrichment_response)
-    
+        self.assertEqual(
+            record.subjects_enrichment, self.mock_enrichment_response
+        )
+
     # Test 7: Record model - has_subjects_enrichment property
     def test_record_has_subjects_enrichment_property(self):
         """Test that Record.has_subjects_enrichment returns correct boolean"""
         from app.records.models import Record
-        
+
         record = Record(self.sample_record_data)
-        
+
         # Test default state (no enrichment data)
         self.assertFalse(record.has_subjects_enrichment)
-        
+
         # Test with empty enrichment data
         record._subjects_enrichment = {}
         self.assertFalse(record.has_subjects_enrichment)
-        
+
         # Test with enrichment data
         record._subjects_enrichment = self.mock_enrichment_response
         self.assertTrue(record.has_subjects_enrichment)
-    
+
     # Test 8: Template rendering with enrichment data
     def test_template_renders_enrichment_correctly(self):
         """Test that the Jinja2 template renders enrichment data correctly"""
@@ -204,22 +221,23 @@ class SubjectsEnrichmentTests(TestCase):
         <p>No enrichment data</p>
         {% endif %}
         """
-        
+
         # Create mock record
         from app.records.models import Record
+
         record = Record(self.sample_record_data)
         record._subjects_enrichment = self.mock_enrichment_response
-        
+
         # Render template
         env = Environment(loader=BaseLoader())
         template = env.from_string(template_string)
         rendered = template.render(record=record)
-        
+
         # Basic assertions
         self.assertIn("Related content", rendered)
         self.assertIn("Enrichment data available", rendered)
         self.assertNotIn("No enrichment data", rendered)
-    
+
     # Test 9: Template with no enrichment data
     def test_template_no_enrichment_data(self):
         """Test template when no enrichment data is available"""
@@ -230,26 +248,27 @@ class SubjectsEnrichmentTests(TestCase):
           <!-- No related content -->
         {% endif %}
         """
-        
+
         from app.records.models import Record
+
         record = Record(self.sample_record_data)
         # Don't set _subjects_enrichment, so has_subjects_enrichment will be False
-        
+
         env = Environment(loader=BaseLoader())
         template = env.from_string(template_string)
         rendered = template.render(record=record)
-        
+
         # Should not render related content section
         self.assertNotIn("Related content", rendered)
-    
+
     # Test 10: Template image rendering with Wagtail API structure
     def test_template_image_rendering(self):
         """Test that images render correctly with Wagtail API image structure"""
-        
+
         # First, let's see what's actually in the mock data
         item_with_image = self.mock_enrichment_response["items"][0]
-        actual_image_title = item_with_image['teaser_image']['title']
-        
+        actual_image_title = item_with_image["teaser_image"]["title"]
+
         # Test basic image presence first
         template_string = """
         {% if subject_item.teaser_image %}
@@ -260,74 +279,72 @@ class SubjectsEnrichmentTests(TestCase):
           <div class="no-image">No image</div>
         {% endif %}
         """
-        
+
         env = Environment(loader=BaseLoader())
         template = env.from_string(template_string)
-        
+
         # Test with image (first item has image)
         rendered = template.render(subject_item=item_with_image)
-        
+
         # Use the ACTUAL title from the mock data, not what we assumed
         self.assertIn('class="has-image"', rendered)
-        self.assertIn(actual_image_title, rendered)  # Use whatever title is actually in the data
-        
+        self.assertIn(
+            actual_image_title, rendered
+        )  # Use whatever title is actually in the data
+
         # Test creating an item without image to verify no image rendering
-        item_without_image = {
-            "title": "Test Item", 
-            "teaser_image": None
-        }
+        item_without_image = {"title": "Test Item", "teaser_image": None}
         rendered = template.render(subject_item=item_without_image)
-        
+
         self.assertIn('class="no-image"', rendered)
-        self.assertNotIn('<img', rendered)
-    
+        self.assertNotIn("<img", rendered)
+
     # Test 11: Three item limit
     def test_template_three_item_limit(self):
         """Test that template only shows maximum 3 items"""
         # Create 5 test items - use simple list access without .items() method
         many_articles = []
         for i in range(5):
-            many_articles.append({
-                "title": f"Article {i+1}",
-                "full_url": f"https://example.com/article-{i+1}",
-                "teaser_text": f"Content for article {i+1}",
-                "is_newly_published": False
-            })
-        
+            many_articles.append(
+                {
+                    "title": f"Article {i + 1}",
+                    "full_url": f"https://example.com/article-{i + 1}",
+                    "teaser_text": f"Content for article {i + 1}",
+                    "is_newly_published": False,
+                }
+            )
+
         template_string = """
         {% for subject_item in article_list[:3] %}
           <div class="item">{{ subject_item.title }}</div>
         {% endfor %}
         """
-        
+
         env = Environment(loader=BaseLoader())
         template = env.from_string(template_string)
         rendered = template.render(article_list=many_articles)
-        
+
         # Should only show first 3 items
         self.assertIn("Article 1", rendered)
         self.assertIn("Article 2", rendered)
         self.assertIn("Article 3", rendered)
         self.assertNotIn("Article 4", rendered)
         self.assertNotIn("Article 5", rendered)
-        
+
         # Should have exactly 3 item divs
         self.assertEqual(rendered.count('class="item"'), 3)
-    
-# Test 12: Record detail view integration  
+
+
+# Test 12: Record detail view integration
 @responses.activate
-@patch('app.records.api.rosetta_request_handler')
+@patch("app.records.api.rosetta_request_handler")
 def test_record_detail_view_includes_enrichment(self, mock_rosetta):
     """Test that record detail view includes enrichment data"""
     # Mock the rosetta API call for getting record details
     mock_rosetta.return_value = {
-        "data": [{
-            "@template": {
-                "details": self.sample_record_data
-            }
-        }]
+        "data": [{"@template": {"details": self.sample_record_data}}]
     }
-    
+
     # Mock the subjects enrichment API call
     responses.add(
         responses.GET,
@@ -335,116 +352,116 @@ def test_record_detail_view_includes_enrichment(self, mock_rosetta):
         json=self.mock_enrichment_response,
         status=200,
     )
-    
+
     # Call the record detail view
     response = self.client.get("/catalogue/id/C123456/")
-    
+
     # Ensure the response is OK
     self.assertEqual(response.status_code, 200)
-    
+
     # For TemplateResponse, we need to render it first to access context
-    if hasattr(response, 'render'):
+    if hasattr(response, "render"):
         response.render()
-    
+
     # Now try to access context_data (for TemplateResponse) or context (for regular response)
-    context_data = getattr(response, 'context_data', None) or getattr(response, 'context', None)
-    
-    if context_data and 'record' in context_data:
-        record = context_data['record']
+    context_data = getattr(response, "context_data", None) or getattr(
+        response, "context", None
+    )
+
+    if context_data and "record" in context_data:
+        record = context_data["record"]
         # Test that the record has the enrichment properties
-        self.assertTrue(hasattr(record, 'has_subjects_enrichment'))
-        self.assertTrue(hasattr(record, 'subjects_enrichment'))
+        self.assertTrue(hasattr(record, "has_subjects_enrichment"))
+        self.assertTrue(hasattr(record, "subjects_enrichment"))
         # Test that enrichment was actually added
         self.assertTrue(record.has_subjects_enrichment)
         self.assertIn("items", record.subjects_enrichment)
-    
+
     # Verify that the enrichment API was called
     self.assertEqual(len(responses.calls), 1)
     self.assertIn("article_tags", responses.calls[0].request.url)
-    
+
     # Check that the response has content
     html = response.content.decode()
     self.assertIsInstance(html, str)
     self.assertGreater(len(html), 0)
-    
+
     # Test 13: Error handling - network timeout
-    @patch('app.records.views.requests.get')
+    @patch("app.records.views.requests.get")
     def test_network_timeout_handling(self, mock_get):
         """Test that network timeouts are handled gracefully"""
         from app.records.views import get_subjects_enrichment
-        
+
         mock_get.side_effect = requests.exceptions.Timeout("Request timed out")
-        
+
         result = get_subjects_enrichment(self.sample_record_data["subjects"])
-        
+
         # Should return empty dict on timeout
         self.assertEqual(result, {})
-    
+
     # Test 14: Error handling - connection error
-    @patch('app.records.views.requests.get')
+    @patch("app.records.views.requests.get")
     def test_connection_error_handling(self, mock_get):
         """Test that connection errors are handled gracefully"""
         from app.records.views import get_subjects_enrichment
-        
-        mock_get.side_effect = requests.exceptions.ConnectionError("Connection failed")
-        
+
+        mock_get.side_effect = requests.exceptions.ConnectionError(
+            "Connection failed"
+        )
+
         result = get_subjects_enrichment(self.sample_record_data["subjects"])
-        
+
         # Should return empty dict on connection error
         self.assertEqual(result, {})
-    
+
     # Test 15: Record detail view with no subjects
-    @patch('app.records.api.rosetta_request_handler')
+    @patch("app.records.api.rosetta_request_handler")
     def test_record_detail_view_no_subjects(self, mock_rosetta):
         """Test record detail view when record has no subjects"""
         # Record data without subjects
         record_data_no_subjects = {
             "iaid": "C123456",
             "title": "Record without subjects",
-            "subjects": []
+            "subjects": [],
         }
-        
+
         mock_rosetta.return_value = {
-            "data": [{
-                "@template": {
-                    "details": record_data_no_subjects
-                }
-            }]
+            "data": [{"@template": {"details": record_data_no_subjects}}]
         }
-        
+
         response = self.client.get("/catalogue/id/C123456/")
-        
+
         self.assertEqual(response.status_code, 200)
-        
+
         # Render the TemplateResponse to access context
         response.render()
-        
+
         # Check that record has empty enrichment
-        record = response.context_data['record']
+        record = response.context_data["record"]
         self.assertFalse(record.has_subjects_enrichment)
         self.assertEqual(record.subjects_enrichment, {})
-    
+
     # Test 16: Logging behavior
     @responses.activate
-    @patch('app.records.views.logger')
+    @patch("app.records.views.logger")
     def test_logging_behavior(self, mock_logger):
         """Test that appropriate logging occurs"""
         from app.records.views import get_subjects_enrichment
-        
+
         responses.add(
             responses.GET,
             "https://test-api.example.com/article_tags",
             json=self.mock_enrichment_response,
             status=200,
         )
-        
+
         get_subjects_enrichment(self.sample_record_data["subjects"])
-        
+
         # Check that success is logged
         mock_logger.info.assert_called_with(
             "Successfully fetched subjects enrichment for: world-war-1939-1945,aviation,royal-air-force,military-operations"
         )
-        
+
         # Test failure logging
         responses.reset()
         responses.add(
@@ -452,8 +469,8 @@ def test_record_detail_view_includes_enrichment(self, mock_rosetta):
             "https://test-api.example.com/article_tags",
             status=500,
         )
-        
+
         get_subjects_enrichment(self.sample_record_data["subjects"])
-        
+
         # Check that failure is logged
         self.assertTrue(mock_logger.warning.called)

--- a/test/records/test_related_content.py
+++ b/test/records/test_related_content.py
@@ -1,0 +1,459 @@
+"""
+Tests for subjects enrichment functionality
+"""
+
+from unittest.mock import Mock, patch
+from django.test import TestCase, override_settings
+import responses
+from jinja2 import Environment, BaseLoader
+from django.utils.text import slugify
+import requests
+
+
+@override_settings(
+    WAGTAIL_API_URL='https://test-api.example.com',
+    SUBJECTS_API_TIMEOUT=5,
+    SUBJECTS_API_LIMIT=10
+)
+class SubjectsEnrichmentTests(TestCase):
+    """Tests for the new subjects enrichment functionality"""
+    
+    def setUp(self):
+        # Sample record data like what comes from your API
+        self.sample_record_data = {
+            "iaid": "C123456",
+            "title": "RAF Operations File",
+            "subjects": ["World War, 1939-1945", "Aviation", "Royal Air Force", "Military operations"]
+        }
+        
+        # Mock enrichment API response (matching Wagtail API structure)
+        self.mock_enrichment_response = {
+            "meta": {"total_count": 3},
+            "items": [
+                {
+                    "id": 1,
+                    "title": "RAF Operations in World War II",
+                    "meta": {
+                        "type": "blog.BlogPage",
+                        "detail_url": "https://test-api.example.com/v2/pages/1/",
+                        "html_url": "https://example.com/guides/raf-operations-wwii",
+                        "slug": "raf-operations-wwii",
+                        "first_published_at": "2023-01-15T10:00:00.000000Z"
+                    },
+                    "introduction": "A comprehensive guide to researching Royal Air Force operations during WWII...",
+                    "teaser_image": {
+                        "id": 123,
+                        "title": "Spitfire aircraft",
+                        "width": 800,
+                        "height": 600,
+                        "download_url": "https://example.com/images/spitfire.jpg"
+                    },
+                    "tags": ["world-war-1939-1945", "aviation", "royal-air-force"]
+                },
+                {
+                    "id": 2,
+                    "title": "New Aviation Documents Discovered",
+                    "meta": {
+                        "type": "blog.BlogPage",
+                        "html_url": "https://example.com/blog/new-aviation-docs",
+                        "first_published_at": "2024-12-01T10:00:00.000000Z"
+                    },
+                    "introduction": "Recently published research on newly discovered aviation documents...",
+                    "teaser_image": None,
+                    "tags": ["aviation"]
+                },
+                {
+                    "id": 3,
+                    "title": "Military Aviation Technology 1939-1945",
+                    "meta": {
+                        "type": "articles.ArticlePage",
+                        "html_url": "https://example.com/articles/aviation-tech",
+                        "first_published_at": "2023-06-10T10:00:00.000000Z"
+                    },
+                    "introduction": "Exploring the technological advances in military aviation...",
+                    "teaser_image": None,
+                    "tags": ["military-operations", "aviation"]
+                }
+            ]
+        }
+    
+    # Test 1: Subject slugification for API calls
+    def test_subject_slugification(self):
+        """Test that subjects are properly slugified for API calls"""
+        test_cases = [
+            ("World War, 1939-1945", "world-war-1939-1945"),
+            ("Aviation", "aviation"),
+            ("Royal Air Force", "royal-air-force"),
+            ("Military operations", "military-operations"),
+            ("D-Day Landings", "d-day-landings"),
+            ("Women's Land Army", "womens-land-army"),
+        ]
+        
+        for subject, expected_slug in test_cases:
+            with self.subTest(subject=subject):
+                actual_slug = slugify(subject)
+                self.assertEqual(actual_slug, expected_slug)
+    
+    # Test 2: Record model - subjects property exists
+    def test_record_subjects_property(self):
+        """Test that Record.subjects property works correctly"""
+        from app.records.models import Record
+        
+        record = Record(self.sample_record_data)
+        
+        # Test that subjects property exists and returns expected data
+        self.assertEqual(len(record.subjects), 4)
+        self.assertIn("World War, 1939-1945", record.subjects)
+        self.assertIn("Aviation", record.subjects)
+        self.assertIn("Royal Air Force", record.subjects)
+        self.assertIn("Military operations", record.subjects)
+    
+    # Test 3: get_subjects_enrichment function success
+    @responses.activate
+    def test_get_subjects_enrichment_success(self):
+        """Test successful API call for subjects enrichment"""
+        from app.records.views import get_subjects_enrichment
+        
+        responses.add(
+            responses.GET,
+            "https://test-api.example.com/article_tags",
+            json=self.mock_enrichment_response,
+            status=200,
+        )
+        
+        result = get_subjects_enrichment(self.sample_record_data["subjects"])
+        
+        self.assertIsInstance(result, dict)
+        self.assertIn("items", result)
+        self.assertEqual(len(result["items"]), 3)
+        self.assertEqual(result["items"][0]["title"], "RAF Operations in World War II")
+        
+        # Check that API was called with correct parameters
+        self.assertEqual(len(responses.calls), 1)
+        request_url = responses.calls[0].request.url
+        self.assertIn("tags=world-war-1939-1945%2Caviation%2Croyal-air-force%2Cmilitary-operations", request_url)
+    
+    # Test 4: get_subjects_enrichment function failure
+    @responses.activate
+    def test_get_subjects_enrichment_failure(self):
+        """Test that API failures are handled gracefully"""
+        from app.records.views import get_subjects_enrichment
+        
+        responses.add(
+            responses.GET,
+            "https://test-api.example.com/article_tags",
+            status=500,
+        )
+        
+        result = get_subjects_enrichment(self.sample_record_data["subjects"])
+        
+        # Should return empty dict on failure
+        self.assertEqual(result, {})
+    
+    # Test 5: get_subjects_enrichment with empty subjects
+    def test_get_subjects_enrichment_empty_subjects(self):
+        """Test get_subjects_enrichment with empty subjects list"""
+        from app.records.views import get_subjects_enrichment
+        
+        result = get_subjects_enrichment([])
+        
+        # Should return empty dict without making API call
+        self.assertEqual(result, {})
+    
+    # Test 6: Record model - subjects_enrichment property
+    def test_record_subjects_enrichment_property(self):
+        """Test that Record.subjects_enrichment works correctly"""
+        from app.records.models import Record
+        
+        record = Record(self.sample_record_data)
+        
+        # Test default state (no enrichment data)
+        self.assertEqual(record.subjects_enrichment, {})
+        
+        # Test with enrichment data
+        record._subjects_enrichment = self.mock_enrichment_response
+        self.assertEqual(record.subjects_enrichment, self.mock_enrichment_response)
+    
+    # Test 7: Record model - has_subjects_enrichment property
+    def test_record_has_subjects_enrichment_property(self):
+        """Test that Record.has_subjects_enrichment returns correct boolean"""
+        from app.records.models import Record
+        
+        record = Record(self.sample_record_data)
+        
+        # Test default state (no enrichment data)
+        self.assertFalse(record.has_subjects_enrichment)
+        
+        # Test with empty enrichment data
+        record._subjects_enrichment = {}
+        self.assertFalse(record.has_subjects_enrichment)
+        
+        # Test with enrichment data
+        record._subjects_enrichment = self.mock_enrichment_response
+        self.assertTrue(record.has_subjects_enrichment)
+    
+    # Test 8: Template rendering with enrichment data
+    def test_template_renders_enrichment_correctly(self):
+        """Test that the Jinja2 template renders enrichment data correctly"""
+        # Simplest test - just check if enrichment data exists
+        template_string = """
+        {% if record.has_subjects_enrichment %}
+        <h2>Related content</h2>
+        <p>Enrichment data available</p>
+        {% else %}
+        <p>No enrichment data</p>
+        {% endif %}
+        """
+        
+        # Create mock record
+        from app.records.models import Record
+        record = Record(self.sample_record_data)
+        record._subjects_enrichment = self.mock_enrichment_response
+        
+        # Render template
+        env = Environment(loader=BaseLoader())
+        template = env.from_string(template_string)
+        rendered = template.render(record=record)
+        
+        # Basic assertions
+        self.assertIn("Related content", rendered)
+        self.assertIn("Enrichment data available", rendered)
+        self.assertNotIn("No enrichment data", rendered)
+    
+    # Test 9: Template with no enrichment data
+    def test_template_no_enrichment_data(self):
+        """Test template when no enrichment data is available"""
+        template_string = """
+        {% if record.has_subjects_enrichment %}
+          <h2>Related content</h2>
+        {% else %}
+          <!-- No related content -->
+        {% endif %}
+        """
+        
+        from app.records.models import Record
+        record = Record(self.sample_record_data)
+        # Don't set _subjects_enrichment, so has_subjects_enrichment will be False
+        
+        env = Environment(loader=BaseLoader())
+        template = env.from_string(template_string)
+        rendered = template.render(record=record)
+        
+        # Should not render related content section
+        self.assertNotIn("Related content", rendered)
+    
+    # Test 10: Template image rendering with Wagtail API structure
+    def test_template_image_rendering(self):
+        """Test that images render correctly with Wagtail API image structure"""
+        
+        # First, let's see what's actually in the mock data
+        item_with_image = self.mock_enrichment_response["items"][0]
+        actual_image_title = item_with_image['teaser_image']['title']
+        
+        # Test basic image presence first
+        template_string = """
+        {% if subject_item.teaser_image %}
+          <div class="has-image">
+            <p>Title: {{ subject_item.teaser_image.title }}</p>
+          </div>
+        {% else %}
+          <div class="no-image">No image</div>
+        {% endif %}
+        """
+        
+        env = Environment(loader=BaseLoader())
+        template = env.from_string(template_string)
+        
+        # Test with image (first item has image)
+        rendered = template.render(subject_item=item_with_image)
+        
+        # Use the ACTUAL title from the mock data, not what we assumed
+        self.assertIn('class="has-image"', rendered)
+        self.assertIn(actual_image_title, rendered)  # Use whatever title is actually in the data
+        
+        # Test creating an item without image to verify no image rendering
+        item_without_image = {
+            "title": "Test Item", 
+            "teaser_image": None
+        }
+        rendered = template.render(subject_item=item_without_image)
+        
+        self.assertIn('class="no-image"', rendered)
+        self.assertNotIn('<img', rendered)
+    
+    # Test 11: Three item limit
+    def test_template_three_item_limit(self):
+        """Test that template only shows maximum 3 items"""
+        # Create 5 test items - use simple list access without .items() method
+        many_articles = []
+        for i in range(5):
+            many_articles.append({
+                "title": f"Article {i+1}",
+                "full_url": f"https://example.com/article-{i+1}",
+                "teaser_text": f"Content for article {i+1}",
+                "is_newly_published": False
+            })
+        
+        template_string = """
+        {% for subject_item in article_list[:3] %}
+          <div class="item">{{ subject_item.title }}</div>
+        {% endfor %}
+        """
+        
+        env = Environment(loader=BaseLoader())
+        template = env.from_string(template_string)
+        rendered = template.render(article_list=many_articles)
+        
+        # Should only show first 3 items
+        self.assertIn("Article 1", rendered)
+        self.assertIn("Article 2", rendered)
+        self.assertIn("Article 3", rendered)
+        self.assertNotIn("Article 4", rendered)
+        self.assertNotIn("Article 5", rendered)
+        
+        # Should have exactly 3 item divs
+        self.assertEqual(rendered.count('class="item"'), 3)
+    
+# Test 12: Record detail view integration  
+@responses.activate
+@patch('app.records.api.rosetta_request_handler')
+def test_record_detail_view_includes_enrichment(self, mock_rosetta):
+    """Test that record detail view includes enrichment data"""
+    # Mock the rosetta API call for getting record details
+    mock_rosetta.return_value = {
+        "data": [{
+            "@template": {
+                "details": self.sample_record_data
+            }
+        }]
+    }
+    
+    # Mock the subjects enrichment API call
+    responses.add(
+        responses.GET,
+        "https://test-api.example.com/article_tags",
+        json=self.mock_enrichment_response,
+        status=200,
+    )
+    
+    # Call the record detail view
+    response = self.client.get("/catalogue/id/C123456/")
+    
+    # Ensure the response is OK
+    self.assertEqual(response.status_code, 200)
+    
+    # For TemplateResponse, we need to render it first to access context
+    if hasattr(response, 'render'):
+        response.render()
+    
+    # Now try to access context_data (for TemplateResponse) or context (for regular response)
+    context_data = getattr(response, 'context_data', None) or getattr(response, 'context', None)
+    
+    if context_data and 'record' in context_data:
+        record = context_data['record']
+        # Test that the record has the enrichment properties
+        self.assertTrue(hasattr(record, 'has_subjects_enrichment'))
+        self.assertTrue(hasattr(record, 'subjects_enrichment'))
+        # Test that enrichment was actually added
+        self.assertTrue(record.has_subjects_enrichment)
+        self.assertIn("items", record.subjects_enrichment)
+    
+    # Verify that the enrichment API was called
+    self.assertEqual(len(responses.calls), 1)
+    self.assertIn("article_tags", responses.calls[0].request.url)
+    
+    # Check that the response has content
+    html = response.content.decode()
+    self.assertIsInstance(html, str)
+    self.assertGreater(len(html), 0)
+    
+    # Test 13: Error handling - network timeout
+    @patch('app.records.views.requests.get')
+    def test_network_timeout_handling(self, mock_get):
+        """Test that network timeouts are handled gracefully"""
+        from app.records.views import get_subjects_enrichment
+        
+        mock_get.side_effect = requests.exceptions.Timeout("Request timed out")
+        
+        result = get_subjects_enrichment(self.sample_record_data["subjects"])
+        
+        # Should return empty dict on timeout
+        self.assertEqual(result, {})
+    
+    # Test 14: Error handling - connection error
+    @patch('app.records.views.requests.get')
+    def test_connection_error_handling(self, mock_get):
+        """Test that connection errors are handled gracefully"""
+        from app.records.views import get_subjects_enrichment
+        
+        mock_get.side_effect = requests.exceptions.ConnectionError("Connection failed")
+        
+        result = get_subjects_enrichment(self.sample_record_data["subjects"])
+        
+        # Should return empty dict on connection error
+        self.assertEqual(result, {})
+    
+    # Test 15: Record detail view with no subjects
+    @patch('app.records.api.rosetta_request_handler')
+    def test_record_detail_view_no_subjects(self, mock_rosetta):
+        """Test record detail view when record has no subjects"""
+        # Record data without subjects
+        record_data_no_subjects = {
+            "iaid": "C123456",
+            "title": "Record without subjects",
+            "subjects": []
+        }
+        
+        mock_rosetta.return_value = {
+            "data": [{
+                "@template": {
+                    "details": record_data_no_subjects
+                }
+            }]
+        }
+        
+        response = self.client.get("/catalogue/id/C123456/")
+        
+        self.assertEqual(response.status_code, 200)
+        
+        # Render the TemplateResponse to access context
+        response.render()
+        
+        # Check that record has empty enrichment
+        record = response.context_data['record']
+        self.assertFalse(record.has_subjects_enrichment)
+        self.assertEqual(record.subjects_enrichment, {})
+    
+    # Test 16: Logging behavior
+    @responses.activate
+    @patch('app.records.views.logger')
+    def test_logging_behavior(self, mock_logger):
+        """Test that appropriate logging occurs"""
+        from app.records.views import get_subjects_enrichment
+        
+        responses.add(
+            responses.GET,
+            "https://test-api.example.com/article_tags",
+            json=self.mock_enrichment_response,
+            status=200,
+        )
+        
+        get_subjects_enrichment(self.sample_record_data["subjects"])
+        
+        # Check that success is logged
+        mock_logger.info.assert_called_with(
+            "Successfully fetched subjects enrichment for: world-war-1939-1945,aviation,royal-air-force,military-operations"
+        )
+        
+        # Test failure logging
+        responses.reset()
+        responses.add(
+            responses.GET,
+            "https://test-api.example.com/article_tags",
+            status=500,
+        )
+        
+        get_subjects_enrichment(self.sample_record_data["subjects"])
+        
+        # Check that failure is logged
+        self.assertTrue(mock_logger.warning.called)


### PR DESCRIPTION
# Pull Request

Ticket URL: https://national-archives.atlassian.net/browse/FIND-319

## About these changes

Using the Wagtail api and subject categories on the details page, obtain related content and display in new panels above the Related Records. Please note that the cards used here are just temporary and will be improved by the frontend team on a different ticket:.

## How to check these changes

In .env, add WAGTAIL_API_URL

Not all records currently have subjects associated with them. Here are a few iaid's that do:

3037d574193840a5ba413193484d3c2f
C10057264
80443cf91825495db09ed2e755871dba

These should all show Related content cards.

Also, where no subjects exist, there should be no cards and no 'Related content' title:

C12301568
