### PR TITLE
FIND-344: Describe the "Display as.." links

### DIFF
--- a/app/templates/search/catalogue.html
+++ b/app/templates/search/catalogue.html
@@ -166,14 +166,14 @@
         <h2 class="tna-visually-hidden">Results layout</h2>
         <div class="tna-button-group tna-button-group--small tna-!--no-margin-top">
           {{ tnaButton({
-            'text': 'List',
+            'text': 'Display as list',
             'href': '?' + qs_replace_value(request.GET, 'display', 'list'),
             'small': True,
             'icon': 'list',
             'iconOnly': True
           }) }}
           {{ tnaButton({
-            'text': 'Grid',
+            'text': 'Display as grid',
             'href': '?' + qs_replace_value(request.GET, 'display', 'grid'),
             'small': True,
             'icon': 'grip',


### PR DESCRIPTION
# Pull Request

[FIND-344](https://national-archives.atlassian.net/browse/FIND-344)

## About these changes

While looking at the accessibility of the search results page I found these links confusing when I encountered them out of context using a screen reader (i.e. using the Safari rotor and navigating by links). I believe this is an issue with SC 2.4.4[^1] so I've added some additional words that describe the link.

[^1]: https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html

## How to check these changes

The simplest way is to inspect the "List" and "Grid" buttons which appear on the search results page and check that the hidden text is now "Display as list" and "Display as grid"

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant


[FIND-344]: https://national-archives.atlassian.net/browse/FIND-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ