### PR TITLE
Refactor 'information' macros for clarity

### DIFF
--- a/app/templates/records/macros/information_below_series_level.html
+++ b/app/templates/records/macros/information_below_series_level.html
@@ -1,6 +1,5 @@
-{% macro information_boxes(record) %}
+{% macro information_below_series_level(record) %}
   {# TODO: Hard coding of levels to remove once we have content for whats_it_about block #}
-  {% if not(record.is_tna and record.level in ["Series", "Division", "Department"]) %}
     <div class="tna-container">
       <div class="tna-column tna-column--width-1-3 tna-column--full-small tna-column--full-tiny tna-!--margin-top-m">
         <div class="tna-aside tna-aside--tight tna-background-accent full-height-aside">
@@ -61,5 +60,4 @@
         </div>
       </div>
     </div>
-  {% endif %}
 {% endmacro %}

--- a/app/templates/records/macros/information_series_level_and_above.html
+++ b/app/templates/records/macros/information_series_level_and_above.html
@@ -1,6 +1,5 @@
-{% macro whats_it_about(record) %}
+{% macro information_series_level_and_above(record) %}
   {# TODO: Hard coding of levels to remove once we have content for whats_it_about block #}
-  {% if record.is_tna and record.level in ["Series", "Division", "Department"] %}
     <div class="tna-container tna-!--margin-top-m">
       <div class="tna-column tna-column--full">
         <div class="tna-!--padding-vertical-m tna-background-accent etna-rounded-corners">
@@ -23,5 +22,4 @@
         </div>
       </div>
     </div>
-  {% endif %}
 {% endmacro %}

--- a/app/templates/records/record_detail.html
+++ b/app/templates/records/record_detail.html
@@ -2,8 +2,8 @@
 
 {%- from 'macros/global_alert_banners.html' import global_alert_banners -%}
 {% from 'records/macros/accordion.html' import etna_accordion %}
-{% from 'records/macros/whats_it_about.html' import whats_it_about %}
-{% from 'records/macros/information_boxes.html' import information_boxes %}
+{% from 'records/macros/information_series_level_and_above.html' import information_series_level_and_above %}
+{% from 'records/macros/information_below_series_level.html' import information_below_series_level %}
 {% from 'records/macros/detail_fields.html' import detail_fields %}
 {% from 'records/macros/hierarchy.html' import hierarchy %}
 {% from 'records/macros/how_to_order.html' import how_to_order %}
@@ -48,9 +48,11 @@
     </div>
   </div>
 
-  {{ whats_it_about(record) }}
-
-  {{ information_boxes(record) }}
+  {% if record.is_tna and record.level in ["Series", "Division", "Department"] %}
+    {{ information_series_level_and_above(record) }}
+  {% else %}
+    {{ information_below_series_level(record) }}
+  {% endif %}
 
   {{ detail_fields(record, field_labels, request) }}
 


### PR DESCRIPTION
## About this change

While exploring availability of properties I can use for FIND-277, I was confused by the macro approach that was in place for 'information' boxes on details pages.
 
This was partly because the inclusion of each macro is mutually exclusive, but they use to opposite 'if' statements, rather than a more explicit 'if'/'else'. I was also confused by the way the conditions were included to wrap the entire macro, rather than being used outside the macro to determine which macro is appropriate.

What I've tried to do here is make the intent clearer by:

* Renaming the files and macros to explain that both are 'information', but one is the information to show where the details page is below series level and the other is for details pages at series level and above
* Change the condition from two 'if's to an 'if else' that is in the template rather than the macro. My goal here is to make their mutual exclusivity immediately apparent

What I haven't done:

* I haven't merged the two macros into one, again because I think they're easier to reason about as two separate macros - each for a specific set of levels. My sense here is that it's better to avoid almost duplicate HTML within a single macro

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant
