### PR TITLE
FIND-291: Additional changes

### DIFF
--- a/app/templates/search/macros/search_results.html
+++ b/app/templates/search/macros/search_results.html
@@ -26,7 +26,7 @@
             </dd>
           </dl>
           <h3><a href="{{ details_url }}">{{ result.summary_title | safe }}</a></h3>
-          <p>{{ result.clean_description | safe | truncate(250) | remove_string_case_insensitive('scope and content') }}</p>
+          <p>{{ result.clean_description | truncate_preserve_mark_tags() | remove_string_case_insensitive('scope and content') | safe }}</p>
           <dl class="etna-result-attributes etna-result-attributes--list">
             <dt>Held by</dt>
             <dd>{{ result.held_by }}</dd>


### PR DESCRIPTION
This pull request introduces two changes to search result snippets that have been requested by the Product Manager today: 

1. Truncate snippets to 250 characters (which has been achieved using the built-in `truncate()` filter
2. Removing instances of "Scope and content" (achieved by introducing a new Jinja2 filter to remove a specified substring from text in a case-insensitive manner). Comprehensive unit tests are added to verify the new filter's behavior.

## How to check these changes

1. Before checking out this branch, perform a search for "*". Note that there are some snippets that contain hundreds of words and the term "Scope and content" appears in several
2. Checkout out this branch and do the same search to confirm all snippets are truncated and none contain the term "Scope and content"

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant