### PR TITLE
FIND-362: Add 'Skip to search filters' link

### DIFF
--- a/app/templates/search/catalogue.html
+++ b/app/templates/search/catalogue.html
@@ -36,15 +36,16 @@
 
 {% block skipLink %}
 {% if results %}
-<a href="#results" class="tna-skip-link" data-module="tna-skip-link">
-  Skip to results
-</a>
+  {{ tnaSkipLink({
+    'href': 'results',
+    'text': 'Skip to results'
+  }) }}
 
 
-{{ tnaSkipLink({
-  'href': 'results',
-  'text': 'Skip to results'
-}) }}
+  {{ tnaSkipLink({
+    'href': 'filter-panel',
+    'text': 'Skip to search filters'
+  }) }}
 {% endif %}
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
# Pull Request

FIND-362

## About these changes

Introduces a new keyboard-access skip link to the search filters, replicating the approach used in JSTOR[^1], including the order of skip links they use.

[^1]: https://www.jstor.org/action/doBasicSearch?Query=test&so=rel

## How to check these changes

Pull this branch and perform a search. On the search results page, use the `tab` key to access skip links. You should find there are three: 

1. Skip to main content
2. Skip to results
3. Skip to search filters

With the 'Skip to search filters' link focused, hitting the `Enter` key should move the user to the "Filters" heading, after which the next click on `tab` should give focus to the first filter checkbox

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant
