### PR TITLE
FIND-389 - Add `content_warning` macro

### DIFF
--- a/app/templates/records/macros/content_warning.html
+++ b/app/templates/records/macros/content_warning.html
@@ -1,0 +1,12 @@
+{%- from 'components/warning/macro.html' import tnaWarning -%}
+
+{% macro content_warning(has_content_warning, warning_text="") %}
+  {% if has_content_warning %}
+    <div class="tna-column tna-column-full tna-!--margin-bottom-s">
+      {{ tnaWarning({
+          "headingLevel": "2",
+          "body": warning_text
+        }) }}
+    </div>
+  {% endif %}
+{% endmacro %}

--- a/app/templates/records/record_detail.html
+++ b/app/templates/records/record_detail.html
@@ -11,6 +11,7 @@
 {% from 'records/macros/top_navigation.html' import top_navigation %}
 {% from 'records/macros/related_records_block.html' import related_records_block %}
 {% from 'records/macros/related_content_block.html' import related_content_block %}
+{% from 'records/macros/content_warning.html' import content_warning %}
 
 {%- set pageTitle = (record.summary_title or '[No title]') | striptags -%}
 
@@ -32,9 +33,13 @@
 <div class="tna-background-accent-">
   {{ global_alert_banners(request, global_alert.global_alert, global_alert.mourning_notice) }}
 </div>
-<div class="tna-section">
+<div class="tna-section tna-!--padding-top-{{ 's' if distressing_content else 'l' }}">
   <div class="tna-container">
-    <div class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+    {{ content_warning(
+        distressing_content,
+        "This record may include content that reflects the trauma and distress experienced by those present during or affected by the event of the time"
+      ) }}
+    <div class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny tna-!--padding-top-xs">
       <hgroup class="tna-hgroup-xl">
         <p class="tna-hgroup__supertitle">{{ record.level }}</p>
         <h1 class="tna-hgroup__title">{{ pageTitle }}</h1>


### PR DESCRIPTION
# Pull Request

[FIND-389](https://national-archives.atlassian.net/browse/FIND-389)

## About these changes

The `content_warning` simply wraps `tnaWarning` with some additional HTML structure to control its presentation within details pages.

<details open>

<summary>Example details page screenshot with banner</summary>

<img width="2896" height="1664" alt="image" src="https://github.com/user-attachments/assets/d4cf9c4c-d573-41cd-9d88-b00f2f414a39" />


</details>



<details open>

<summary>Example details page screenshot without banner</summary>

<img width="2896" height="1664" alt="image" src="https://github.com/user-attachments/assets/8f2f5156-f5b1-4134-9f29-adebe6ff9afc" />


</details>

## How to check these changes

Having cloned this branch:

1. Set an environment variable as follows `DCS_PREFIXES="HO 616,AB 41,J 14,LOC 5,HO 397,ILB 2,LEV 1,GTI 2,GTI 102,ICSA 1,ICSA 2,ICSA 3,ICSA 4,ICSA 5,ICSA 6,ICSA 7,ES 38"` (I had to rebuild my Docker containers for the environment variable to take effect)
2. Visit a [details page that **does not have** a content warning](http://localhost:65533/catalogue/id/C4303326/?search=cT1zb21ldGhpbmcmZGlzcGxheT1saXN0Jmdyb3VwPXRuYSZkYXRlX2Zyb20teWVhcj0mZGF0ZV9mcm9tLXllYXI9JmRhdGVfZnJvbS1tb250aD0mZGF0ZV9mcm9tLW1vbnRoPSZkYXRlX2Zyb20tZGF5PSZkYXRlX2Zyb20tZGF5PSZkYXRlX3RvLXllYXI9JmRhdGVfdG8teWVhcj0mZGF0ZV90by1tb250aD0mZGF0ZV90by1tb250aD0mZGF0ZV90by1kYXk9JmRhdGVfdG8tZGF5PSZzb3J0PQ==). You should not see the content warning
3. Visit a [details page that **does have** a content warning](http://localhost:65533/catalogue/id/C5096549/?search=cT1BZHZpc29yeStDb21taXR0ZWUrb24rU3BlY2lhbCtNYXRlcmlhbHMlM0ErcGFwZXJzK0FCKzQxJTJGNSZkaXNwbGF5PWxpc3QmZ3JvdXA9dG5hJmRhdGVfZnJvbS15ZWFyPSZkYXRlX2Zyb20teWVhcj0mZGF0ZV9mcm9tLW1vbnRoPSZkYXRlX2Zyb20tbW9udGg9JmRhdGVfZnJvbS1kYXk9JmRhdGVfZnJvbS1kYXk9JmRhdGVfdG8teWVhcj0mZGF0ZV90by15ZWFyPSZkYXRlX3RvLW1vbnRoPSZkYXRlX3RvLW1vbnRoPSZkYXRlX3RvLWRheT0mZGF0ZV90by1kYXk9JnNvcnQ9). You should see the content warning 

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant


[FIND-389]: https://national-archives.atlassian.net/browse/FIND-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ