### PR TITLE
FIND-509:run asgi locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,14 +13,10 @@ services:
         "config.asgi:application",
         "--log-level",
         "debug",
-        "--timeout-keep-alive",
-        "30",
         "--host",
         "0.0.0.0",
         "--port",
         "8080",
-        "--lifespan",
-        "off",
         "--reload",
       ]
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       ]
     environment:
       - ENVIRONMENT_NAME=localhost
-      - APPLICATION_PROTOCOL=http
       - DEBUG=True
       - DJANGO_SETTINGS_MODULE=config.settings.develop
       - SECRET_KEY=abc123

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,27 @@ services:
       args:
         IMAGE: ghcr.io/nationalarchives/tna-python-dev
         IMAGE_TAG: preview
+    command:
+      [
+        "poetry",
+        "run",
+        "uvicorn",
+        "config.asgi:application",
+        "--log-level",
+        "debug",
+        "--timeout-keep-alive",
+        "30",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8080",
+        "--lifespan",
+        "off",
+        "--reload",
+      ]
     environment:
       - ENVIRONMENT_NAME=localhost
+      - APPLICATION_PROTOCOL=http
       - DEBUG=True
       - DJANGO_SETTINGS_MODULE=config.settings.develop
       - SECRET_KEY=abc123


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-509](https://national-archives.atlassian.net/browse/FIND-509)

## About these changes
To match asgi running in EC2, run asgi locally
- runs asgi locally
- reload : automatically restarts when there's a code change

## How to check these changes

`docker compose up -d`

Verify ASGI runs - docker app1 logs
```
INFO:     Will watch for changes in these directories: ['/app']
INFO:     Uvicorn running on http://0.0.0.0:8080/ (Press CTRL+C to quit)
INFO:     Started reloader process [1] using StatReload
INFO:     Started server process [12]
INFO:     Waiting for application startup.
INFO:     ASGI 'lifespan' protocol appears unsupported.
INFO:     Application startup complete.
INFO:     127.0.0.1:56676 - "GET /healthcheck/live/ HTTP/1.1" 200 OK
```

`docker compose exec app poetry run python manage.py test --settings=config.settings.test`
`docker compose exec app format`
http://localhost:65533/catalogue/search/
http://localhost:65533/catalogue/id/C2773

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensure main branch is deployable and all non-live features are behind flags.
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant


[FIND-509]: https://national-archives.atlassian.net/browse/FIND-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ