### PR TITLE
FIND-346:update current catalogue link for TNA archon page

### DIFF
--- a/app/records/models.py
+++ b/app/records/models.py
@@ -642,10 +642,7 @@ class Record(APIModel):
         if self.custom_record_type == RecordTypes.ARCHON:
             if self.reference_number == TNA_ARCHON_CODE:
                 # Discovery * search for Tna records
-                params = {
-                    "_q": "*",
-                    "_hb": "tna"
-                }
+                params = {"_q": "*", "_hb": "tna"}
             else:
                 # For other records, link to Discovery search results filtered for the record's
                 # archon reference number

--- a/app/records/models.py
+++ b/app/records/models.py
@@ -641,15 +641,18 @@ class Record(APIModel):
 
         if self.custom_record_type == RecordTypes.ARCHON:
             if self.reference_number == TNA_ARCHON_CODE:
-                # landing page for Discovery
-                return f"{BASE_TNA_DISCOVERY_URL}"
+                # Discovery * search for Tna records
+                params = {
+                    "_q": "*",
+                    "_hb": "tna"
+                }
             else:
+                # For other records, link to Discovery search results filtered for the record's
+                # archon reference number
                 params = {
                     "_q": "*",
                     "_hb": "oth",
                     "_nrar": self.reference_number,
                 }
-                # For other records, link to Discovery search results filtered for the record's
-                # archon reference number
-                return f"{BASE_TNA_DISCOVERY_URL}/results/r?{urlencode(params)}"
+            return f"{BASE_TNA_DISCOVERY_URL}/results/r?{urlencode(params)}"
         return ""

--- a/test/records/test_archon_archivescollections_urls.py
+++ b/test/records/test_archon_archivescollections_urls.py
@@ -113,5 +113,5 @@ class TnaArchonRecordCollectionUrlTests(SimpleTestCase):
 
         self.assertEqual(
             self.record.archon_discovery_url,
-            "https://discovery.nationalarchives.gov.uk",
+            "https://discovery.nationalarchives.gov.uk/results/r?_q=%2A&_hb=tna",
         )


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-346](https://national-archives.atlassian.net/browse/FIND-346)

Related [PR # 180](https://github.com/nationalarchives/ds-catalogue/pull/180)

## About these changes

Updates Discovery URL link in "Current Catalogue" - "View all collections in the current catalogue for TNA Archon" - to navigate to search results with TNA filter
Current: https://discovery.nationalarchives.gov.uk/
Updated: https://discovery.nationalarchives.gov.uk/results/r?_q=*&_hb=tna

## How to check these changes

http://localhost:65533/catalogue/id/A13530124/

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensure main branch is deployable and all non-live features are behind flags.
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant


[FIND-346]: https://national-archives.atlassian.net/browse/FIND-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ