### PR TITLE
CHORE: Broader local development guidance, develop with other services locally

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Provides search functionality to query historical and public documents known as 
 
 For help setting up a development environment, see the project README.
 
-For broader local development guidance used across services, see the higher-level local development guide:
+For broader local development guidance used across services, see the higher-level local development guide (requires TNA Atlassian access):
 <https://national-archives.atlassian.net/wiki/spaces/TW/pages/775028742/Local+development>
 
 ## Updating this documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,9 @@ Provides search functionality to query historical and public documents known as 
 
 For help setting up a development environment, see the project README.
 
+For broader local development guidance used across services, see the higher-level local development guide:
+<https://national-archives.atlassian.net/wiki/spaces/TW/pages/775028742/Local+development>
+
 ## Updating this documentation
 
 The navigation for this documentation is configured in `mkdocs.yml` at the project root. You can add new markdown files there to get them to appear in the navigation.

--- a/docs/local-development-gotchas.md
+++ b/docs/local-development-gotchas.md
@@ -2,7 +2,7 @@
 
 This page lists common local development issues and how do resolve them.
 
-For broader local development guidance used across services, see:
+For broader local development guidance used across services, see the internal TNA Atlassian page below (requires TNA Atlassian access):
 <https://national-archives.atlassian.net/wiki/spaces/TW/pages/775028742/Local+development>
 
 ## Catalogue Landing Page and Global Notifications
@@ -48,6 +48,12 @@ To test the catalogue landing page and global notifications locally:
 The app will fetch and cache the data from the configured Wagtail API endpoints.
 
 ### Clear Global Notifications cache on `ds-catalogue`
+
+```
+$ docker compose exec app poetry run python manage.py clear_global_notifications_cache
+```
+
+To clear the entire Django cache instead, use:
 
 ```
 $ docker compose exec app poetry run python manage.py clearcache

--- a/docs/local-development-gotchas.md
+++ b/docs/local-development-gotchas.md
@@ -47,14 +47,3 @@ To test the catalogue landing page and global notifications locally:
 
 The app will fetch and cache the data from the configured Wagtail API endpoints.
 
-### Clear Global Notifications cache on `ds-catalogue`
-
-```
-$ docker compose exec app poetry run python manage.py clear_global_notifications_cache
-```
-
-To clear the entire Django cache instead, use:
-
-```
-$ docker compose exec app poetry run python manage.py clearcache
-```

--- a/docs/local-development-gotchas.md
+++ b/docs/local-development-gotchas.md
@@ -46,3 +46,9 @@ To test the catalogue landing page and global notifications locally:
    ```
 
 The app will fetch and cache the data from the configured Wagtail API endpoints.
+
+### Clear Global Notifications cache on `ds-catalogue`
+
+```
+$ docker compose exec app poetry run python manage.py clearcache
+```

--- a/docs/local-development-gotchas.md
+++ b/docs/local-development-gotchas.md
@@ -1,3 +1,6 @@
 # Local development gotchas
 
 This page lists common local development issues and how do resolve them.
+
+For broader local development guidance used across services, see:
+<https://national-archives.atlassian.net/wiki/spaces/TW/pages/775028742/Local+development>

--- a/docs/local-development-gotchas.md
+++ b/docs/local-development-gotchas.md
@@ -47,3 +47,8 @@ To test the catalogue landing page and global notifications locally:
 
 The app will fetch and cache the data from the configured Wagtail API endpoints.
 
+### Clears Django cache on `ds-catalogue`
+
+```
+$ docker compose exec app poetry run python manage.py clearcache
+```

--- a/docs/local-development-gotchas.md
+++ b/docs/local-development-gotchas.md
@@ -4,3 +4,45 @@ This page lists common local development issues and how do resolve them.
 
 For broader local development guidance used across services, see:
 <https://national-archives.atlassian.net/wiki/spaces/TW/pages/775028742/Local+development>
+
+## Catalogue Landing Page and Global Notifications
+
+This app integrates with [ds-wagtail](https://github.com/nationalarchives/ds-wagtail) to display the catalogue landing page and global notifications across the application.
+
+### API Endpoints Accessed
+
+This app makes requests to the following Wagtail API endpoints:
+
+- `GET /api/v2/globals/notifications/` - Fetches global alerts and mourning notices
+- `GET /api/v2/catalogue/landing/` - Fetches landing page data including top pages and latest articles
+
+These endpoints are accessed at the base URL configured via `WAGTAIL_API_URL`.
+
+### Local Development Setup
+
+To test the catalogue landing page and global notifications locally:
+
+1. **Configure the Wagtail API URL:** Set `WAGTAIL_API_URL` to point to your local ds-wagtail instance:
+
+   ```
+   WAGTAIL_API_URL=http://host.docker.internal:8000/api/v2
+   ```
+
+   This is already configured in `docker-compose.yml` for local development.
+
+2. **Set up ds-wagtail:** Follow the setup instructions in the [ds-wagtail repository](https://github.com/nationalarchives/ds-wagtail) to:
+   - Install and run the ds-wagtail service
+   - Create the required pages and global notifications through the Wagtail admin interface
+
+   See the ds-wagtail documentation for specific steps on creating:
+   - A "Catalogue Landing" page
+   - Global notification content (alerts, mourning notices)
+
+3. **Run ds-catalogue:** Start the catalogue app:
+   ```
+   $ docker compose up -d
+   $ aws sso login
+   $ ./dev/pull
+   ```
+
+The app will fetch and cache the data from the configured Wagtail API endpoints.


### PR DESCRIPTION
# Pull Request

Ticket URL: NA

## About these changes

- adds link to higher level local development documentation which is generic for all services. 
- adds guidance to use other services in local development 
 [ds-wagtail](https://github.com/nationalarchives/ds-wagtail)  with setting present in docker-compose i.e. `WAGTAIL_API_URL=http://host.docker.internal:8000/api/v2` and check landing page, global notifications
- adds guidance to clear global notifications cache locally.

## How to check these changes

- Must have AWS SSO access to dev and CLI installed.
- run `ds-wagtail` locally along with this app.
- setup global notifications
- view Landing http://localhost:65533/catalogue/ (parts from ds-wagtail - explore the collection, discover something new and notifications)
- view Search http://localhost:65533/catalogue/search (notifications)
- view Record details http://localhost:65533/catalogue/id/C16411 (notifications)

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensure main branch is deployable and all non-live features are behind flags.
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant
