### PR TITLE
FIND-509: document asgi run locally for debugging asgi issues raised in sentry 

### DIFF
--- a/docs/local-development-gotchas.md
+++ b/docs/local-development-gotchas.md
@@ -6,15 +6,19 @@ This page lists common local development issues and how do resolve them.
 
 In order to run ASGI as it does in production locally
 
-- remove or comment out `docker-compose`
-  ```
-  args:
-    IMAGE: ghcr.io/nationalarchives/tna-python-dev
-    IMAGE_TAG: preview
-  ```
-  This will revert to using the default specified in the Dockerfile which is `ghcr.io/nationalarchives/tna-python`, the production image.
-- Add
-  ```
-  environment:
-      - APPLICATION_PROTOCOL=http
-  ```
+1. Remove or comment out in `docker-compose` below:
+
+```
+args:
+  IMAGE: ghcr.io/nationalarchives/tna-python-dev
+  IMAGE_TAG: preview
+```
+
+This will revert to using the default specified in the Dockerfile which is `ghcr.io/nationalarchives/tna-python`, the production image.
+
+2. Add
+
+```
+environment:
+    - APPLICATION_PROTOCOL=http
+```

--- a/docs/local-development-gotchas.md
+++ b/docs/local-development-gotchas.md
@@ -1,3 +1,20 @@
 # Local development gotchas
 
 This page lists common local development issues and how do resolve them.
+
+## Debugging with running ASGI locally using Production image.
+
+In order to run ASGI as it does in production locally
+
+- remove or comment out `docker-compose`
+  ```
+  args:
+    IMAGE: ghcr.io/nationalarchives/tna-python-dev
+    IMAGE_TAG: preview
+  ```
+  This will revert to using the default specified in the Dockerfile which is `ghcr.io/nationalarchives/tna-python`, the production image.
+- Add
+  ```
+  environment:
+      - APPLICATION_PROTOCOL=http
+  ```


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-509](https://national-archives.atlassian.net/browse/FIND-509?focusedCommentId=220921)

## About these changes

Following [PR#182](https://github.com/nationalarchives/ds-catalogue/pull/182) and discussion in `ds-etna-dev`, we’ve aligned on the intended approach for debugging ASGI-specific behaviour (e.g. Warning: StreamingHttpResponse,  [Cancelled Error - sentry](https://the-national-archives.sentry.io/issues/7185325236/?alert_rule_id=15274532&alert_type=issue&notification_uuid=7a2d4f99-cfc5-41a9-88ae-400108fe91bb&project=4507458864087040&referrer=slack)).

Current understanding is:

- Standard local development remains based on the WSGI/dev server setup.
- When reproduction of prod-only async behaviour is required, the prod image tna-python`can be used locally to investigate these cases.

This will be treated as the expected workflow for now, to ensure consistency when debugging these issues.


## How to check these changes

Follow instructions and review local development access with ASGI

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensure main branch is deployable and all non-live features are behind flags.
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant


[FIND-509]: https://national-archives.atlassian.net/browse/FIND-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ