### PR TITLE
FIND-345:remove debug line

### DIFF
--- a/app/templates/records/archon_detail.html
+++ b/app/templates/records/archon_detail.html
@@ -48,7 +48,6 @@
         {{ record.description | sanitise_record_field | safe }}
       </div>
     </div>
-    has_place_description ={{ has_place_description }}
 
     {% if has_place_description %}
       <div class="tna-column tna-column--width-1-2 tna-column--full-tiny tna-column--full-small tna-!--margin-top-m">


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-345](https://national-archives.atlassian.net/browse/FIND-345?focusedCommentId=220833) Enhancement 

## About these changes

After deploying to dev-beta, I observed a debug line `has_place_description =` shows below Contact Information

Remove debug line introduced in [PR#185](https://github.com/nationalarchives/ds-catalogue/pull/185)
https://github.com/nationalarchives/ds-catalogue/blob/582f06cb398ceb113c7999ae024594305a578012/app/templates/records/archon_detail.html#L51

## How to check these changes

The debug line should be removed.
http://localhost:65533/catalogue/id/A13531666/ 
http://localhost:65533/catalogue/id/A13531985/ 

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensure main branch is deployable and all non-live features are behind flags.
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant


[FIND-345]: https://national-archives.atlassian.net/browse/FIND-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ