### PR TITLE
Fix deploy docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
# Pull Request

Ticket URL: NA

## About these changes

Issue:
Deploy Doc did not run for [PR#202](https://github.com/nationalarchives/ds-catalogue/pull/202)  - Chore/update python dependencies doc which contains only changes for docs. So those changes were unpublished.

This PR adds `workflow_dispatch` event to the docs deploy workflow 
- that will allow to redeploy docs without pushing a new commit.
- retry failed deployments manually. 

## How to check these changes

Manually trigger deploy docs workflow when merged to check above PR#202 deployed.

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensure main branch is deployable and all non-live features are behind flags.
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant
