### PR TITLE
CHORE:add guidance to ensure merge is unblocked

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,4 @@ Where possible, provide guidance to help your reviewer
 - Ensured that PR includes only commits relevant to the ticket
 - Waited for all CI jobs to pass before requesting a review
 - Added/updated tests and documentation where relevant
-- Ensure the merge is unblocked (e.g., all commits have verified signatures).
+- Ensure the merge is unblocked (e.g., all commits have verified signatures)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,4 @@ Where possible, provide guidance to help your reviewer
 - Ensured that PR includes only commits relevant to the ticket
 - Waited for all CI jobs to pass before requesting a review
 - Added/updated tests and documentation where relevant
+- Ensure the merge is unblocked (e.g., all commits have verified signatures).

--- a/docs/git-test.md
+++ b/docs/git-test.md
@@ -1,0 +1,1 @@
+# Test GPG signing


### PR DESCRIPTION
# Pull Request

Ticket URL: [EDEV-193](https://national-archives.atlassian.net/browse/EDEV-193)

## About these changes

Following the recent organisation-wide ruleset changes discussed in Slack, this PR adds a reminder to the PR template to help contributors identify merge blockers (such as unsigned commits) before requesting review.

## How to check these changes

- Check the message  `Ensure the merge is unblocked (e.g., all commits have verified signatures)` in the PR check list.

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensure main branch is deployable and all non-live features are behind flags.
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant


[EDEV-193]: https://national-archives.atlassian.net/browse/EDEV-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ