### PR TITLE
EDEV-193:add guidance to ensure merge is unblocked - signed commit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,8 @@ Where possible, provide guidance to help your reviewer
 
 - Checked things thoroughly before handing over to reviewer
 - Checked PR title starts with ticket number as per project conventions to help us keep track of changes
-- Ensure main branch is deployable and all non-live features are behind flags.
+- Ensured main branch is deployable and all non-live features are behind flags.
 - Ensured that PR includes only commits relevant to the ticket
 - Waited for all CI jobs to pass before requesting a review
 - Added/updated tests and documentation where relevant
+- Ensured the merge is unblocked (e.g., all commits have verified signatures)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ Where possible, provide guidance to help your reviewer
 
 - Checked things thoroughly before handing over to reviewer
 - Checked PR title starts with ticket number as per project conventions to help us keep track of changes
-- Ensured main branch is deployable and all non-live features are behind flags.
+- Ensured main branch is deployable and all non-live features are behind flags
 - Ensured that PR includes only commits relevant to the ticket
 - Waited for all CI jobs to pass before requesting a review
 - Added/updated tests and documentation where relevant

--- a/docs/project-conventions.md
+++ b/docs/project-conventions.md
@@ -21,6 +21,11 @@ Useful links
 
 ## Git/Github conventions
 
+### Signed Commits
+
+    Ensure commits are signed before pushing to GitHub
+    See 4. Security <https://nationalarchives.github.io/engineering-handbook/third-party/github/>
+
 ### Branching
 
 - Changes are developed in feature branches and submitted as pull requests via Github


### PR DESCRIPTION
# Pull Request

Ticket URL: [EDEV-193](https://national-archives.atlassian.net/browse/EDEV-193)

## About these changes

Following the recent organisation-wide ruleset changes discussed in Slack, this PR adds a reminder to the PR template to help contributors identify merge blockers (such as unsigned commits) before requesting review.

Also adds guidance to Project Conventions on using signed commits.

## How to check these changes

- Check the message  `Ensured the merge is unblocked (e.g., all commits have verified signatures)` in the PR check list.

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensure main branch is deployable and all non-live features are behind flags.
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant


[EDEV-193]: https://national-archives.atlassian.net/browse/EDEV-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ