### PR TITLE
Chore/Provided coverage for 404/500 views

### DIFF
--- a/test/errors/test_urls.py
+++ b/test/errors/test_urls.py
@@ -1,0 +1,14 @@
+from django.test import SimpleTestCase
+from django.utils.module_loading import import_string
+
+from app.errors.views import page_not_found_error_view
+
+
+class Handler404WiringTestCase(SimpleTestCase):
+    """The custom 404 handler only fires when DEBUG is False, so nothing else
+    exercises it. This guards against a typo'd dotted path or a moved view."""
+
+    def test_handler404_resolves_to_error_view(self):
+        from config.urls import handler404
+
+        self.assertIs(import_string(handler404), page_not_found_error_view)

--- a/test/errors/test_views.py
+++ b/test/errors/test_views.py
@@ -1,0 +1,68 @@
+from http import HTTPStatus
+from unittest.mock import patch
+
+from django.http import HttpResponse, HttpResponseServerError
+from django.template import TemplateDoesNotExist
+from django.test import RequestFactory, SimpleTestCase
+
+from app.errors.constants import PAGE_NOT_FOUND_TEMPLATE, SERVER_ERROR_TEMPLATE
+from app.errors.views import page_not_found_error_view, server_error_view
+
+
+class PageNotFoundErrorViewTestCase(SimpleTestCase):
+    def setUp(self):
+        self.request = RequestFactory().get("/missing/")
+
+    @patch("app.errors.views.render")
+    def test_renders_template_with_404_status(self, mock_render):
+        mock_render.return_value = HttpResponse(b"not found")
+        response = page_not_found_error_view(self.request)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        mock_render.assert_called_once_with(
+            self.request,
+            PAGE_NOT_FOUND_TEMPLATE,
+            context={"status_code": HTTPStatus.NOT_FOUND},
+        )
+
+    @patch("app.errors.views.render")
+    def test_explicit_status_code_propagates(self, mock_render):
+        mock_render.return_value = HttpResponse(b"gone")
+        response = page_not_found_error_view(self.request, status_code=HTTPStatus.GONE)
+        self.assertEqual(response.status_code, HTTPStatus.GONE)
+        mock_render.assert_called_once_with(
+            self.request,
+            PAGE_NOT_FOUND_TEMPLATE,
+            context={"status_code": HTTPStatus.GONE},
+        )
+
+    @patch("app.errors.views.render")
+    def test_falls_back_to_500_when_template_missing(self, mock_render):
+        mock_render.side_effect = TemplateDoesNotExist(PAGE_NOT_FOUND_TEMPLATE)
+        response = page_not_found_error_view(self.request)
+        self.assertIsInstance(response, HttpResponseServerError)
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertIn(b"Template not found", response.content)
+
+
+class ServerErrorViewTestCase(SimpleTestCase):
+    def setUp(self):
+        self.request = RequestFactory().get("/boom/")
+
+    @patch("app.errors.views.render")
+    def test_renders_template_with_500_status(self, mock_render):
+        mock_render.return_value = HttpResponse(b"server error")
+        response = server_error_view(self.request)
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        mock_render.assert_called_once_with(
+            self.request,
+            SERVER_ERROR_TEMPLATE,
+            context={"status_code": HTTPStatus.INTERNAL_SERVER_ERROR},
+        )
+
+    @patch("app.errors.views.render")
+    def test_falls_back_to_500_when_template_missing(self, mock_render):
+        mock_render.side_effect = TemplateDoesNotExist(SERVER_ERROR_TEMPLATE)
+        response = server_error_view(self.request)
+        self.assertIsInstance(response, HttpResponseServerError)
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertIn(b"Template not found", response.content)


### PR DESCRIPTION
# Pull Request
Ticket URL: None

## About these changes
Adds test coverage for the error views, which previously had none. Covers `page_not_found_error_view` and `server_error_view` — the correct 404/500 status codes, and the `TemplateDoesNotExist` fallback returning a 500 rather than blowing up — plus a wiring test that `handler404` resolves to the real view (it only fires when `DEBUG=False`, so nothing else exercises it).

No production code changes; tests only.

## How to check these changes
- Run `test/errors/` and `test/config/test_urls.py` — both should be green.
- The fallback tests patch `render`, so no templates or DB are needed.

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensured main branch is deployable and all non-live features are behind flags
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant
- Ensured the merge is unblocked (e.g., all commits have verified signatures)
