### PR TITLE
Chore/find 499 code quality findings

### DIFF
--- a/app/templates/records/archon_detail.html
+++ b/app/templates/records/archon_detail.html
@@ -7,8 +7,9 @@
 {%- set pageTitle = (record.title or record.summary_title or '[No title]') | striptags -%}
 {% set has_place_description = record.place_description %}
 {% set full_width_class = "tna-column tna-column--full tna-!--margin-top-l" %}
-{% set split_width_class = "tna-column tna-column--full-tiny tna-column--full-small tna-column--width-1-2 tna-!--margin-top-m" %}
-{% set contact_class = split_width_class if has_place_description else full_width_class %}
+{% set contact_class = "tna-column tna-column--full-tiny tna-column--full-small tna-column--width-1-2 tna-!--margin-top-m" 
+          if has_place_description
+          else full_width_class %}
 
 {% block stylesheets %}
 {{ super() }}

--- a/app/templates/records/archon_detail.html
+++ b/app/templates/records/archon_detail.html
@@ -7,9 +7,8 @@
 {%- set pageTitle = (record.title or record.summary_title or '[No title]') | striptags -%}
 {% set has_place_description = record.place_description %}
 {% set full_width_class = "tna-column tna-column--full tna-!--margin-top-l" %}
-{% set contact_class = "tna-column tna-column--full-tiny tna-column--full-small tna-column--width-1-2 tna-!--margin-top-m" 
-          if has_place_description
-          else full_width_class %}
+{% set split_width_class = "tna-column tna-column--full-tiny tna-column--full-small tna-column--width-1-2 tna-!--margin-top-m" %}
+{% set contact_class = split_width_class if has_place_description else full_width_class %}
 
 {% block stylesheets %}
 {{ super() }}

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -48,7 +48,7 @@ docker compose exec dev poetry add --group <group-name> <package-name>
 
 See the [Poetry docs](https://python-poetry.org/docs/cli/#add) for more options.
 
-### Removing a dependency
+## Removing a dependency
 
 ```sh
 docker compose exec app poetry remove DateTime

--- a/docs/project-conventions.md
+++ b/docs/project-conventions.md
@@ -19,7 +19,7 @@ Useful links
 - <https://github.com/nationalarchives/docker/tree/main/docker/tna-python-dev#ruff>
 - <https://nationalarchives.github.io/engineering-handbook/technology/backend/python/>
 
-## Git/Github conventions
+## Git/GitHub conventions
 
 ### Signed Commits
 
@@ -28,7 +28,7 @@ Useful links
 
 ### Branching
 
-- Changes are developed in feature branches and submitted as pull requests via Github
+- Changes are developed in feature branches and submitted as pull requests via GitHub
 - Feature branches should always be based on: `main`
 - Create a new branch if the branch for that ticket has been merged.
 

--- a/test/lib/test_xslt_transformations.py
+++ b/test/lib/test_xslt_transformations.py
@@ -763,7 +763,7 @@ class XsltTransformationsTestCase(unittest.TestCase):
 
         with self.assertLogs("app.lib.xslt_transformations", level="WARNING") as lc:
             return_value = xsl_transformation(source, schema)
-            self.assertIn("", return_value)
+            self.assertEqual("", return_value)
 
         self.assertIn(
             "WARNING:app.lib.xslt_transformations:Empty source provided for XSLT transformation",

--- a/test/search/test_view_display.py
+++ b/test/search/test_view_display.py
@@ -136,7 +136,7 @@ class CatalogueSearchViewDisplayTests(TestCase):
         html = force_str(response.content)
 
         self.assertIsInstance(form, CatalogueSearchCommonForm)
-        self.assertEqual(form.is_valid(), False)
+        self.assertFalse(form.is_valid())
 
         self.assertEqual(
             form.errors,

--- a/test/search/test_views_collection_filter.py
+++ b/test/search/test_views_collection_filter.py
@@ -521,7 +521,7 @@ class CatalogueSearchViewCollectionFilterTests(TestCase):
     #         "collection"
     #     ]
 
-    #     self.assertEqual(form.is_valid(), False)
+    #     self.assertFalse(form.is_valid())
 
     #     # returns None when errors present
     #     self.assertEqual(context_data.get("results"), None)

--- a/test/search/test_views_held_by_filter.py
+++ b/test/search/test_views_held_by_filter.py
@@ -81,7 +81,7 @@ class CatalogueSearchViewHeldByFilterTests(TestCase):
         form = context_data.get("form")
         held_by_field = form.fields[FieldsConstant.HELD_BY]
 
-        self.assertEqual(form.is_valid(), True)
+        self.assertTrue(form.is_valid())
 
         self.assertIsInstance(context_data.get("results"), list)
         self.assertEqual(len(context_data.get("results")), 2)
@@ -193,7 +193,7 @@ class CatalogueSearchViewHeldByFilterTests(TestCase):
         form = context_data.get("form")
         held_by_field = form.fields["held_by"]
 
-        self.assertEqual(form.is_valid(), True)
+        self.assertTrue(form.is_valid())
 
         self.assertEqual(context_data.get("results"), [])
         self.assertEqual(context_data.get("results_range"), None)

--- a/test/search/test_views_invalid_group.py
+++ b/test/search/test_views_invalid_group.py
@@ -21,7 +21,7 @@ class CatalogueSearchViewInvalidViewTests(TestCase):
         html = force_str(response.content)
 
         self.assertIsInstance(form, CatalogueSearchBaseForm)
-        self.assertEqual(form.is_valid(), False)
+        self.assertFalse(form.is_valid())
 
         self.assertEqual(
             form.errors,

--- a/test/search/test_views_level_filter.py
+++ b/test/search/test_views_level_filter.py
@@ -63,7 +63,7 @@ class CatalogueSearchViewLevelFilterTests(TestCase):
         form = response.context_data.get("form")
         level_field = response.context_data.get("form").fields[FieldsConstant.LEVEL]
 
-        self.assertEqual(form.is_valid(), True)
+        self.assertTrue(form.is_valid())
 
         self.assertEqual(level_field.value, ["Department", "Division"])
         self.assertEqual(
@@ -134,7 +134,7 @@ class CatalogueSearchViewLevelFilterTests(TestCase):
 
         html = force_str(response.content)
 
-        self.assertEqual(form.is_valid(), False)
+        self.assertFalse(form.is_valid())
 
         # test for presence of hidden inputs for invalid level params
         self.assertIn("""<input type="hidden" name="level" value="Item">""", html)

--- a/test/search/test_views_query_param.py
+++ b/test/search/test_views_query_param.py
@@ -101,7 +101,7 @@ class CatalogueSearchViewQueryParamTests(TestCase):
         self.assertEqual(response.context_data.get("total"), None)
 
         # no errors, but no results
-        self.assertEqual(form.is_valid(), True)
+        self.assertTrue(form.is_valid())
         self.assertEqual(form.errors, {})
 
         self.assertFalse(response.context_data.get("filters_visible"))

--- a/test/search/test_views_sort_param.py
+++ b/test/search/test_views_sort_param.py
@@ -82,7 +82,7 @@ class CatalogueSearchViewSortParamTests(TestCase):
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsInstance(form, CatalogueSearchTnaForm)
-        self.assertEqual(form.is_valid(), False)
+        self.assertFalse(form.is_valid())
         self.assertEqual(
             form.errors,
             {
@@ -115,7 +115,7 @@ class CatalogueSearchViewSortParamTests(TestCase):
         form = response.context_data.get("form")
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertEqual(form.is_valid(), False)
+        self.assertFalse(form.is_valid())
 
         self.assertEqual(response.context_data.get("selected_filters"), [])
         self.assertFalse(response.context_data.get("filters_visible"))


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-499](https://national-archives.atlassian.net/browse/FIND-499)

## About these changes

[AI Findings:](https://github.com/nationalarchives/ds-catalogue/security/quality/ai-findings)

1) docs/dependency-management.md
The 'Removing a dependency' section is a sub-heading (###) under 'Adding a dependency' (##), but it is a sibling concept, not a child. It should be promoted to a top-level section (##) to match the structure of the other sections.

2) docs/project-conventions.md
Corrected spelling of 'Github' to 'GitHub'.

3) test/search/test_views_sort_param.py
Use 'assertFalse(form.is_valid())' instead of 'assertEqual(form.is_valid(), False)' for boolean assertions. This provides clearer test failure messages.

4)  test/lib/test_xslt_transformations.py
`self.assertIn("", return_value)` always passes because the empty string is a substring of any string. This assertion does not actually verify that the return value is an empty string. It should be `self.assertEqual("", return_value)` to properly assert that an empty string is returned when the source is `None`.

## How to check these changes

Non functional changes
Regression:
`docker compose exec app poetry run python manage.py test --settings=config.settings.test`


## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensured main branch is deployable and all non-live features are behind flags
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant
- Ensured the merge is unblocked (e.g., all commits have verified signatures)


[FIND-499]: https://national-archives.atlassian.net/browse/FIND-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ