### PR TITLE
Fix/find 554 subject filter persisting after uncheck

### DIFF
--- a/app/search/views.py
+++ b/app/search/views.py
@@ -613,6 +613,7 @@ class CatalogueSearchView(SearchDataLayerMixin, CatalogueSearchFormMixin):
             )
             if field_name:
                 filter_context["mfc_field"] = self.form.fields.get(field_name)
+                filter_context["aggregation"] = Aggregation
         return filter_context
 
     def build_selected_filters_list(self):

--- a/app/templates/search/filter_list.html
+++ b/app/templates/search/filter_list.html
@@ -105,7 +105,7 @@
         </div>
       </div>
     </div>
-    {{ render_hidden_fields(request, form, bucket_keys, mfc_field) }}
+    {{ render_hidden_fields(request, form, bucket_keys, mfc_field, aggregation) }}
   </form>
 
   <div class="tna-background-accent-light">

--- a/app/templates/search/macros/render_hidden_fields.html
+++ b/app/templates/search/macros/render_hidden_fields.html
@@ -3,7 +3,7 @@
 {% from 'search/macros/as_hidden_for_date_input.html' import as_hidden_for_date_input %}
 {% from 'search/macros/as_hidden_for_checkboxes.html' import as_hidden_for_checkboxes %}
 
-{% macro render_hidden_fields(request, form, bucket_keys, mfc_field) %}
+{% macro render_hidden_fields(request, form, bucket_keys, mfc_field, aggregation) %}
   {{ as_hidden_for_single_value(form.fields.group) }}
   {{ as_hidden_for_single_value(form.fields.q) }}
   <input type="hidden" name="display" value="{{ request.GET.get('display') or 'list' }}">
@@ -13,7 +13,10 @@
     {{ as_hidden_for_date_input(form.fields.covering_date_from) }}
     {{ as_hidden_for_date_input(form.fields.covering_date_to) }}
     {{ as_hidden_for_checkboxes(form.fields.collection) }}
-    {{ as_hidden_for_checkboxes(form.fields.subject) }}
+    {# Avoid duplicate subject field #}
+    {% if mfc_field.name != aggregation.SUBJECT.field_name %}
+      {{ as_hidden_for_checkboxes(form.fields.subject) }}
+    {% endif %}
     {{ as_hidden_for_checkboxes(form.fields.level) }}
     {{ as_hidden_for_date_input(form.fields.opening_date_from) }}
     {{ as_hidden_for_date_input(form.fields.opening_date_to) }}

--- a/test/search/test_views_long_filter_collection.py
+++ b/test/search/test_views_long_filter_collection.py
@@ -222,6 +222,7 @@ class CatalogueSearchViewCollectionMoreFilterChoicesTests(TestCase):
             "&level=Piece"
             "&covering_date_from-year=1940"
             "&filter_list=longCollection"
+            "&subject=Army"
         )
 
         context_data = response.context_data
@@ -242,6 +243,7 @@ class CatalogueSearchViewCollectionMoreFilterChoicesTests(TestCase):
                 "&level=Item"
                 "&level=Piece"
                 "&covering_date_from-year=1940"
+                "&subject=Army"
             ),
         )
         self.assertIsInstance(
@@ -282,6 +284,7 @@ class CatalogueSearchViewCollectionMoreFilterChoicesTests(TestCase):
         self.assertIn("""<input type="hidden" name="online" value="true">""", html)
         self.assertIn("""<input type="hidden" name="level" value="Item">""", html)
         self.assertIn("""<input type="hidden" name="level" value="Piece">""", html)
+        self.assertIn("""<input type="hidden" name="subject" value="Army">""", html)
         self.assertIn(
             """<input type="hidden" name="covering_date_from-year" value="1940">""",
             html,

--- a/test/search/test_views_long_filter_subject.py
+++ b/test/search/test_views_long_filter_subject.py
@@ -220,6 +220,7 @@ class CatalogueSearchViewSubjectMoreFilterChoicesTests(TestCase):
             "&level=Piece"
             "&covering_date_from-year=1940"
             "&filter_list=longSubject"
+            "&subject=Army"
         )
 
         context_data = response.context_data
@@ -240,6 +241,7 @@ class CatalogueSearchViewSubjectMoreFilterChoicesTests(TestCase):
                 "&level=Item"
                 "&level=Piece"
                 "&covering_date_from-year=1940"
+                "&subject=Army"
             ),
         )
         self.assertIsInstance(
@@ -258,6 +260,7 @@ class CatalogueSearchViewSubjectMoreFilterChoicesTests(TestCase):
                     "value": "International",
                 },
                 {
+                    "checked": True,
                     "text": "Army (35)",
                     "value": "Army",
                 },
@@ -290,3 +293,4 @@ class CatalogueSearchViewSubjectMoreFilterChoicesTests(TestCase):
         self.assertNotIn(
             """<input type="hidden" name="covering_date_from-day" """, html
         )
+        self.assertNotIn("""<input type="hidden" name="subject" """, html)


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-554](https://national-archives.atlassian.net/browse/FIND-554)

## About these changes

Subject field is rendered twice - as checkbox and hidden fields when See more subjects is queried with a Subject
When the Subject in question is unchecked, and filters are applied, due to the Hidden field, the Subject remains checked.
The fix addresses this issue.

## How to check these changes

- Change local ROSETTA_API_URL in docker compose to reflect prod
- http://localhost:65533/catalogue/search/?subject=Education&filter_list=longSubject
   Uncheck Education and Apply Filters
   Education is now unchecked

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensured main branch is deployable and all non-live features are behind flags
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant
- Ensured the merge is unblocked (e.g., all commits have verified signatures)


[FIND-554]: https://national-archives.atlassian.net/browse/FIND-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ