### PR TITLE
FIND-556 Fix tag colour when subject picker is in dark mode

### DIFF
--- a/app/templates/main/subject-picker.html
+++ b/app/templates/main/subject-picker.html
@@ -1,4 +1,4 @@
-<div class="tna-block-accent-light tna-!--padding-vertical-s">
+<div class="tna-background-accent-light tna-!--padding-vertical-s">
   <div class="tna-container">
     <div class="tna-column tna-column--full">
 


### PR DESCRIPTION
# Pull Request

Ticket URL: [FIND-556](https://national-archives.atlassian.net/browse/FIND-556)

## About these changes

Use correct class to inherit tag colour when using dark mode

## How to check these changes

Subject picker can be found at `/catalogue/`

## Before assigning to reviewer, please make sure you have

- Checked things thoroughly before handing over to reviewer
- Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- Ensured main branch is deployable and all non-live features are behind flags
- Ensured that PR includes only commits relevant to the ticket
- Waited for all CI jobs to pass before requesting a review
- Added/updated tests and documentation where relevant
- Ensured the merge is unblocked (e.g., all commits have verified signatures)


[FIND-556]: https://national-archives.atlassian.net/browse/FIND-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ